### PR TITLE
fix: Use correct name

### DIFF
--- a/Sources/WMATA/Rail/Lines.swift
+++ b/Sources/WMATA/Rail/Lines.swift
@@ -50,7 +50,7 @@ public extension Line {
             return "Silver"
 
         case .YLRP:
-            return "Yellow Rush Push"
+            return "Yellow Rush Plus"
         }
     }
 }


### PR DESCRIPTION
WMATA branded the extra Yellow services "Rush Plus" (see https://www.wmata.com/about/news/pressreleasedetail.cfm?ReleaseID=5186), not "Rush Push". Even through the Rush Plus service is no more, it would be good to have this corrected if WMATA returns to it.