### PR TITLE
feat: add functions to get stations that are together

### DIFF
--- a/Sources/WMATA/Rail/Stations.swift
+++ b/Sources/WMATA/Rail/Stations.swift
@@ -545,7 +545,7 @@ public extension Station {
     /// This is effectively the result of joining the `StationTogether1`
     /// and `StationTogether2` values from the WMATA API.
     /// - Returns: The other stations together with this station or an empty array
-    func together() -> [Station] {
+    var together: [Station] {
         switch self {
         // Fort Totten
         case .B06:
@@ -574,10 +574,8 @@ public extension Station {
 
     /// Other stations located with this station, including this station.
     /// - Returns: This station appended to the results of `together`.
-    func allTogether() -> [Station] {
-        var together = self.together()
-        together.append(self)
-        return together
+    var allTogether: [Station] {
+        together + [self]
     }
 }
 

--- a/Sources/WMATA/Rail/Stations.swift
+++ b/Sources/WMATA/Rail/Stations.swift
@@ -540,6 +540,45 @@ public extension Station {
             minute: openingTimeDateComponents.minute!
         ).date!
     }
+
+    /// Other stations located with this station, but on different lines.
+    /// This is effectively the result of joining the `StationTogether1`
+    /// and `StationTogether2` values from the WMATA API.
+    /// - Returns: The other stations together with this station or an empty array
+    func together() -> [Station] {
+        switch self {
+        // Fort Totten
+        case .B06:
+            return [.E06]
+        case .E06:
+            return [.B06]
+        // Gallery Pl-Chinatown
+        case .B01:
+            return [.F01]
+        case .F01:
+            return [.B01]
+        // L'Enfant Plaza
+        case .D03:
+            return [.F03]
+        case .F03:
+            return [.D03]
+        // Metro Center
+        case .A01:
+            return [.C01]
+        case .C01:
+            return [.A01]
+        default:
+            return []
+        }
+    }
+
+    /// Other stations located with this station, including this station.
+    /// - Returns: This station appended to the results of `together`.
+    func allTogether() -> [Station] {
+        var together = self.together()
+        together.append(self)
+        return together
+    }
 }
 
 extension Station: CustomStringConvertible {

--- a/Tests/WMATATests/WMATATests.swift
+++ b/Tests/WMATATests/WMATATests.swift
@@ -946,6 +946,18 @@ final class StationTests: XCTestCase {
 
         XCTAssertEqual(Station.A01.openingTime(on: date), date)
     }
+
+    func testStationTogether() {
+        XCTAssertEqual(Station.A01.together(), [Station.C01])
+        XCTAssertEqual(Station.C01.together(), [Station.A01])
+        XCTAssertEqual(Station.A02.together(), [])
+    }
+
+    func testStationAllTogether() {
+        XCTAssertEqual(Station.A01.allTogether(), [Station.C01, Station.A01])
+        XCTAssertEqual(Station.C01.allTogether(), [Station.A01, Station.C01])
+        XCTAssertEqual(Station.A02.allTogether(), [Station.A02])
+    }
 }
 
 final class MetroBusTests: XCTestCase {

--- a/Tests/WMATATests/WMATATests.swift
+++ b/Tests/WMATATests/WMATATests.swift
@@ -948,15 +948,15 @@ final class StationTests: XCTestCase {
     }
 
     func testStationTogether() {
-        XCTAssertEqual(Station.A01.together(), [Station.C01])
-        XCTAssertEqual(Station.C01.together(), [Station.A01])
-        XCTAssertEqual(Station.A02.together(), [])
+        XCTAssertEqual(Station.A01.together, [Station.C01])
+        XCTAssertEqual(Station.C01.together, [Station.A01])
+        XCTAssertEqual(Station.A02.together, [])
     }
 
     func testStationAllTogether() {
-        XCTAssertEqual(Station.A01.allTogether(), [Station.C01, Station.A01])
-        XCTAssertEqual(Station.C01.allTogether(), [Station.A01, Station.C01])
-        XCTAssertEqual(Station.A02.allTogether(), [Station.A02])
+        XCTAssertEqual(Station.A01.allTogether, [Station.C01, Station.A01])
+        XCTAssertEqual(Station.C01.allTogether, [Station.A01, Station.C01])
+        XCTAssertEqual(Station.A02.allTogether, [Station.A02])
     }
 }
 


### PR DESCRIPTION
Since WMATA codes each station with multiple lines that do not share tracks as separate stations in their API, provide methods to get stations at the same location in an array.

This provides to functions:
- `together()` which gets the other stations at the same location
- `allTogether()` which appends the current station to the results of `together()`

The use case for these methods is to to get all nextTrain results for a single multi-platform station (Fort Totten, Gallery Pl-Chinatown, L'Enfant Plaze, or Metro Center) in a single API call.