### PR TITLE
fix: provide public constructors

### DIFF
--- a/Sources/WMATA/Location.swift
+++ b/Sources/WMATA/Location.swift
@@ -11,6 +11,15 @@ public struct RadiusAtCoordinates {
     public let radius: UInt
     public let coordinates: Coordinates
 
+    public init(radius: UInt, coordinates: Coordinates) {
+        self.radius = radius
+        self.coordinates = coordinates
+    }
+
+    public init(radius: UInt, latitude: Double, longitude: Double) {
+        self.init(radius: radius, coordinates: Coordinates(latitude: latitude, longitude: longitude))
+    }
+
     func toQueryItems() -> [(String, String)] {
         return coordinates.toQueryItems() + [
             ("Radius", String(radius)),
@@ -21,6 +30,11 @@ public struct RadiusAtCoordinates {
 public struct Coordinates {
     public let latitude: Double
     public let longitude: Double
+
+    public init(latitude: Double, longitude: Double) {
+        self.latitude = latitude
+        self.longitude = longitude
+    }
 
     func toQueryItems() -> [(String, String)] {
         return [

--- a/Tests/WMATATests/WMATATests.swift
+++ b/Tests/WMATATests/WMATATests.swift
@@ -1530,4 +1530,10 @@ final class MetroBusTests: XCTestCase {
 
         waitForExpectations(timeout: 1)
     }
+
+    func testRadiusAtCoordinatesLatLongInit() {
+        let radius = RadiusAtCoordinates(radius: 1, latitude: 1.0, longitude: 1.0)
+        XCTAssertEqual(radius.coordinates.latitude, 1.0)
+        XCTAssertEqual(radius.coordinates.longitude, 1.0)
+    }
 }


### PR DESCRIPTION
Swift synthesizes internal constructors instead of public constructors, making it impossible to call funcs requiring a RadiusAtCoordinates or Coordinates object as a parameter.

Also provide a convience constructor for RadiusAtCoordinates that takes a latitude and longitude as parameters.