### PR TITLE
v9.0.1: Compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,12 @@ import PackageDescription
 
 let package = Package(
     name: "WMATA",
+    platforms: [
+        .macOS(.v10_14),
+        .iOS(.v12),
+        .tvOS(.v12),
+        .watchOS(.v5)
+    ],
     products: [
         .library(
             name: "WMATA",

--- a/Sources/WMATA/Bus/BusProtocols.swift
+++ b/Sources/WMATA/Bus/BusProtocols.swift
@@ -138,7 +138,7 @@ extension NeedsRoute {
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension NeedsRoute {
-    func positions(on route: Route?, at radiusAtCoordinates: RadiusAtCoordinates?, key: String, session: URLSession) -> AnyPublisher<BusPositions, WMATAError> {
+    func positionsPublisher(on route: Route?, at radiusAtCoordinates: RadiusAtCoordinates?, key: String, session: URLSession) -> AnyPublisher<BusPositions, WMATAError> {
         var queryItems = [(String, String)]()
 
         if let route = route {
@@ -155,7 +155,7 @@ extension NeedsRoute {
         )
     }
 
-    func incidents(on route: Route?, key: String, session: URLSession) -> AnyPublisher<BusIncidents, WMATAError> {
+    func incidentsPublisher(on route: Route?, key: String, session: URLSession) -> AnyPublisher<BusIncidents, WMATAError> {
         var queryItems = [(String, String)]()
 
         if let route = route {
@@ -168,7 +168,7 @@ extension NeedsRoute {
         )
     }
 
-    func pathDetails(for route: Route, on date: WMATADate? = nil, key: String, session: URLSession) -> AnyPublisher<PathDetails, WMATAError> {
+    func pathDetailsPublisher(for route: Route, on date: WMATADate? = nil, key: String, session: URLSession) -> AnyPublisher<PathDetails, WMATAError> {
         var queryItems = [("RouteID", route.id)]
 
         if let date = date {
@@ -181,7 +181,7 @@ extension NeedsRoute {
         )
     }
 
-    func schedule(for route: Route, on date: WMATADate? = nil, includingVariations: Bool? = false, key: String, session: URLSession) -> AnyPublisher<RouteSchedule, WMATAError> {
+    func schedulePublisher(for route: Route, on date: WMATADate? = nil, includingVariations: Bool? = false, key: String, session: URLSession) -> AnyPublisher<RouteSchedule, WMATAError> {
         var queryItems = [("RouteID", route.id)]
 
         if let date = date {
@@ -247,14 +247,14 @@ extension NeedsStop {
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension NeedsStop {
-    func nextBuses(for stop: Stop, key: String, session: URLSession) -> AnyPublisher<BusPredictions, WMATAError> {
+    func nextBusesPublisher(for stop: Stop, key: String, session: URLSession) -> AnyPublisher<BusPredictions, WMATAError> {
         publisher(
             request: URLRequest(url: BusURL.nextBuses.rawValue, key: key, queryItems: [("StopID", stop.id)]),
             session: session
         )
     }
 
-    func schedule(for stop: Stop, at date: WMATADate? = nil, key: String, session: URLSession) -> AnyPublisher<StopSchedule, WMATAError> {
+    func schedulePublisher(for stop: Stop, at date: WMATADate? = nil, key: String, session: URLSession) -> AnyPublisher<StopSchedule, WMATAError> {
         var queryItems = [("StopID", stop.id)]
 
         if let date = date {

--- a/Sources/WMATA/Bus/Routes.swift
+++ b/Sources/WMATA/Bus/Routes.swift
@@ -72,7 +72,7 @@ public extension Route {
     /// - Parameter session: Optional. URL Session to make this request with
     /// - returns: A Combine Publisher for `BusPositions`
     func positionsPublisher(at radiusAtCoordinates: RadiusAtCoordinates?, key: String, session: URLSession = URLSession.shared) -> AnyPublisher<BusPositions, WMATAError> {
-        (self as NeedsRoute).positions(on: self, at: radiusAtCoordinates, key: key, session: session)
+        (self as NeedsRoute).positionsPublisher(on: self, at: radiusAtCoordinates, key: key, session: session)
     }
 
     /// Bus incidents along this Route.
@@ -80,7 +80,7 @@ public extension Route {
     /// - Parameter session: Optional. URL Session to make this request with
     /// - returns: A Combine Publisher for `BusIncidents`
     func incidentsPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<BusIncidents, WMATAError> {
-        (self as NeedsRoute).incidents(on: self, key: key, session: session)
+        (self as NeedsRoute).incidentsPublisher(on: self, key: key, session: session)
     }
 
     /// Ordered latlong points along this Route for a given date.
@@ -89,7 +89,7 @@ public extension Route {
     /// - Parameter session: Optional. URL Session to make this request with
     /// - returns: A Combine Publisher for `PathDetails`
     func pathDetailsPublisher(on date: WMATADate? = nil, key: String, session: URLSession = URLSession.shared) -> AnyPublisher<PathDetails, WMATAError> {
-        (self as NeedsRoute).pathDetails(for: self, on: date, key: key, session: session)
+        (self as NeedsRoute).pathDetailsPublisher(for: self, on: date, key: key, session: session)
     }
 
     /// Scheduled stops for this Route
@@ -99,7 +99,7 @@ public extension Route {
     /// - Parameter session: Optional. URL Session to make this request with
     /// - returns: A Combine Publisher for `RoutesResponse`
     func schedulePublisher(on date: WMATADate? = nil, includingVariations: Bool? = false, key: String, session: URLSession = URLSession.shared) -> AnyPublisher<RouteSchedule, WMATAError> {
-        (self as NeedsRoute).schedule(for: self, on: date, includingVariations: includingVariations, key: key, session: session)
+        (self as NeedsRoute).schedulePublisher(for: self, on: date, includingVariations: includingVariations, key: key, session: session)
     }
 }
 

--- a/Sources/WMATA/Bus/Stops.swift
+++ b/Sources/WMATA/Bus/Stops.swift
@@ -50,7 +50,7 @@ public extension Stop {
     /// - Parameter session: Optional. URL Session to make this request with
     /// - returns: A Combine Publisher for `BusPredictions`
     func nextBusesPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<BusPredictions, WMATAError> {
-        (self as NeedsStop).nextBuses(for: self, key: key, session: session)
+        (self as NeedsStop).nextBusesPublisher(for: self, key: key, session: session)
     }
 
     /// Set of buses scheduled to arrive at this Stop at a given date.
@@ -59,7 +59,7 @@ public extension Stop {
     /// - Parameter session: Optional. URL Session to make this request with
     /// - returns: A Combine Publisher for `StopSchedule`
     func schedulePublisher(at date: WMATADate? = nil, key: String, session: URLSession = URLSession.shared) -> AnyPublisher<StopSchedule, WMATAError> {
-        (self as NeedsStop).schedule(for: self, at: date, key: key, session: session)
+        (self as NeedsStop).schedulePublisher(for: self, at: date, key: key, session: session)
     }
 }
 

--- a/Sources/WMATA/MetroBus.swift
+++ b/Sources/WMATA/MetroBus.swift
@@ -212,7 +212,7 @@ public extension MetroBus {
     /// - parameter radiusAtCoordinates: Radius at latitude and longitude to search at
     /// - returns: A Combine Publisher for`BusPositions`
     func positionsPublisher(on route: Route?, at radiusAtCoordinates: RadiusAtCoordinates?) -> AnyPublisher<BusPositions, WMATAError> {
-        (self as NeedsRoute).positions(on: route, at: radiusAtCoordinates, key: key, session: session)
+        (self as NeedsRoute).positionsPublisher(on: route, at: radiusAtCoordinates, key: key, session: session)
     }
 
     /// Bus incidents along a given route.
@@ -220,7 +220,7 @@ public extension MetroBus {
     /// - parameter route: Route to search for incidents along. Omit route to receive all incidents.
     /// - returns: A Combine Publisher for`BusIncidents`
     func incidentsPublisher(on route: Route?) -> AnyPublisher<BusIncidents, WMATAError> {
-        (self as NeedsRoute).incidents(on: route, key: key, session: session)
+        (self as NeedsRoute).incidentsPublisher(on: route, key: key, session: session)
     }
 
     /// Ordered latlong points along this Route for a given date. Omit date to get path information for today.
@@ -229,7 +229,7 @@ public extension MetroBus {
     /// - parameter date: `WMATADate`  for which to receive path information. Omit for today.
     /// - returns: A Combine Publisher for`PathDetails`
     func pathDetailsPublisher(for route: Route, on date: WMATADate? = nil) -> AnyPublisher<PathDetails, WMATAError> {
-        (self as NeedsRoute).pathDetails(for: route, on: date, key: key, session: session)
+        (self as NeedsRoute).pathDetailsPublisher(for: route, on: date, key: key, session: session)
     }
 
     /// Scheduled stops for this Route
@@ -239,7 +239,7 @@ public extension MetroBus {
     /// - parameter includingVariations: Whether to include route variations. Example: B30v1 and B30v2 for Route B30
     /// - returns: A Combine Publisher for`RouteSchedule`
     func routeSchedulePublisher(for route: Route, on date: WMATADate? = nil, includingVariations: Bool? = false) -> AnyPublisher<RouteSchedule, WMATAError> {
-        (self as NeedsRoute).schedule(for: route, on: date, includingVariations: includingVariations, key: key, session: session)
+        (self as NeedsRoute).schedulePublisher(for: route, on: date, includingVariations: includingVariations, key: key, session: session)
     }
 }
 
@@ -288,7 +288,7 @@ public extension MetroBus {
     /// - parameter stop: Stop to get next arrival times for
     /// - returns: A Combine Publisher for `BusPredictions`
     func nextBusesPublisher(for stop: Stop) -> AnyPublisher<BusPredictions, WMATAError> {
-        (self as NeedsStop).nextBuses(for: stop, key: key, session: session)
+        (self as NeedsStop).nextBusesPublisher(for: stop, key: key, session: session)
     }
 
     /// Set of buses scheduled to arrive at this Stop at a given date.
@@ -297,7 +297,7 @@ public extension MetroBus {
     /// - parameter date: `WMATADate` for which to receive schedule for. Omit for today.
     /// - returns: A Combine Publisher for `StopSchedule`
     func stopSchedulePublisher(for stop: Stop, at date: WMATADate? = nil) -> AnyPublisher<StopSchedule, WMATAError> {
-        (self as NeedsStop).schedule(for: stop, at: date, key: key, session: session)
+        (self as NeedsStop).schedulePublisher(for: stop, at: date, key: key, session: session)
     }
 }
 

--- a/Sources/WMATA/MetroRail.swift
+++ b/Sources/WMATA/MetroRail.swift
@@ -379,7 +379,7 @@ public extension MetroRail {
     /// - parameter destinationStation: Station to travel to
     /// - returns: A Combine Publisher for `StationToStationInfos`
     func stationPublisher(_ station: Station?, to destinationStation: Station?) -> AnyPublisher<StationToStationInfos, WMATAError> {
-        (self as NeedsStation).station(station, to: destinationStation, key: key, session: urlSession)
+        (self as NeedsStation).stationPublisher(station, to: destinationStation, key: key, session: urlSession)
     }
 
     /// Reported elevator and escalator incidents
@@ -387,7 +387,7 @@ public extension MetroRail {
     /// - parameter station: Which station to search for incidents at. Optional.
     /// - returns: A Combine Publisher for `ElevatorAndEscalatorIncidents`
     func elevatorAndEscalatorIncidentsPublisher(at station: Station?) -> AnyPublisher<ElevatorAndEscalatorIncidents, WMATAError> {
-        (self as NeedsStation).elevatorAndEscalatorIncidents(at: station, key: key, session: urlSession)
+        (self as NeedsStation).elevatorAndEscalatorIncidentsPublisher(at: station, key: key, session: urlSession)
     }
 
     /// Reported MetroRail incidents
@@ -395,7 +395,7 @@ public extension MetroRail {
     /// - parameter station: Station to search for incidents at. Optional.
     /// - returns: A Combine Publisher for `RailIncidents`
     func incidentsPublisher(at station: Station?) -> AnyPublisher<RailIncidents, WMATAError> {
-        (self as NeedsStation).incidents(at: station, key: key, session: urlSession)
+        (self as NeedsStation).incidentsPublisher(at: station, key: key, session: urlSession)
     }
 
     /// Next train arrival information for this station
@@ -403,7 +403,7 @@ public extension MetroRail {
     /// - parameter station: `Station` to search for trains at
     /// - returns: A Combine Publisher for  `RailPredictions`
     func nextTrainsPublisher(at station: Station) -> AnyPublisher<RailPredictions, WMATAError> {
-        (self as NeedsStation).nextTrains(at: station, key: key, session: urlSession)
+        (self as NeedsStation).nextTrainsPublisher(at: station, key: key, session: urlSession)
     }
 
     /// Next train arrival information for the given stations
@@ -411,7 +411,7 @@ public extension MetroRail {
     /// - parameter stations: `[Station]`s to look up next trains for
     /// - returns: A Combine Publisher for  `RailPredictions`
     func nextTrainsPublisher(at stations: [Station]) -> AnyPublisher<RailPredictions, WMATAError> {
-        (self as NeedsStation).nextTrains(at: stations, key: key, session: urlSession)
+        (self as NeedsStation).nextTrainsPublisher(at: stations, key: key, session: urlSession)
     }
 
     /// Location and address information for this station
@@ -419,7 +419,7 @@ public extension MetroRail {
     /// - parameter station: `StationCode` search for information for
     /// - returns: A Combine Publisher for `StationInformation`
     func informationPublisher(for station: Station) -> AnyPublisher<StationInformation, WMATAError> {
-        (self as NeedsStation).information(for: station, key: key, session: urlSession)
+        (self as NeedsStation).informationPublisher(for: station, key: key, session: urlSession)
     }
 
     /// Parking information for this station
@@ -427,7 +427,7 @@ public extension MetroRail {
     /// - parameter station: `StationCode` to search for parking information for
     /// - returns: A Combine Publisher for `StationsParking`
     func parkingInformationPublisher(for station: Station) -> AnyPublisher<StationsParking, WMATAError> {
-        (self as NeedsStation).parkingInformation(for: station, key: key, session: urlSession)
+        (self as NeedsStation).parkingInformationPublisher(for: station, key: key, session: urlSession)
     }
 
     /// Returns a set of ordered stations and distances between two stations _on the same line_
@@ -436,7 +436,7 @@ public extension MetroRail {
     /// - parameter destinationStation: Destination station to pathfind to
     /// - returns: A Combine Publisher for  `PathBetweenStations`
     func pathPublisher(from startingStation: Station, to destinationStation: Station) -> AnyPublisher<PathBetweenStations, WMATAError> {
-        (self as NeedsStation).path(from: startingStation, to: destinationStation, key: key, session: urlSession)
+        (self as NeedsStation).pathPublisher(from: startingStation, to: destinationStation, key: key, session: urlSession)
     }
 
     /// Opening and scheduled first and last trains for this station
@@ -444,7 +444,7 @@ public extension MetroRail {
     /// - parameter station: `StationCode` to search for timings for
     /// - returns: A Combine Publisher for  `StationTimings`
     func timingsPublisher(for station: Station) -> AnyPublisher<StationTimings, WMATAError> {
-        (self as NeedsStation).timings(for: station, key: key, session: urlSession)
+        (self as NeedsStation).timingsPublisher(for: station, key: key, session: urlSession)
     }
 }
 
@@ -475,7 +475,7 @@ public extension MetroRail {
     /// - parameter line: Line to receive stations along. Omit to receive all stations.
     /// - returns: A Combine Publisher for `Stations`
     func stationsPublisher(for line: Line?) -> AnyPublisher<Stations, WMATAError> {
-        (self as NeedsLine).stations(for: line, key: key, session: urlSession)
+        (self as NeedsLine).stationsPublisher(for: line, key: key, session: urlSession)
     }
 }
 

--- a/Sources/WMATA/Rail/Lines.swift
+++ b/Sources/WMATA/Rail/Lines.swift
@@ -38,7 +38,7 @@ public extension Line {
     /// - Parameter session: Optional. URL Session to make this request with
     /// - returns: A Combine Publisher for `Stations`
     func stationsPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<Stations, WMATAError> {
-        (self as NeedsLine).stations(for: self, key: key, session: session)
+        (self as NeedsLine).stationsPublisher(for: self, key: key, session: session)
     }
 }
 

--- a/Sources/WMATA/Rail/RailProtocols.swift
+++ b/Sources/WMATA/Rail/RailProtocols.swift
@@ -216,7 +216,7 @@ extension NeedsStation {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension NeedsStation {
     /// For requests using Combine
-    func station(_ station: Station?, to destinationStation: Station?, key: String, session: URLSession) -> AnyPublisher<StationToStationInfos, WMATAError> {
+    func stationPublisher(_ station: Station?, to destinationStation: Station?, key: String, session: URLSession) -> AnyPublisher<StationToStationInfos, WMATAError> {
         var queryItems = [(String, String)]()
 
         if let station = station {
@@ -233,7 +233,7 @@ extension NeedsStation {
         )
     }
 
-    func elevatorAndEscalatorIncidents(at station: Station?, key: String, session: URLSession) -> AnyPublisher<ElevatorAndEscalatorIncidents, WMATAError> {
+    func elevatorAndEscalatorIncidentsPublisher(at station: Station?, key: String, session: URLSession) -> AnyPublisher<ElevatorAndEscalatorIncidents, WMATAError> {
         var queryItems = [(String, String)]()
 
         if let station = station {
@@ -246,7 +246,7 @@ extension NeedsStation {
         )
     }
 
-    func incidents(at station: Station?, key: String, session: URLSession) -> AnyPublisher<RailIncidents, WMATAError> {
+    func incidentsPublisher(at station: Station?, key: String, session: URLSession) -> AnyPublisher<RailIncidents, WMATAError> {
         var queryItems = [(String, String)]()
 
         if let station = station {
@@ -259,14 +259,14 @@ extension NeedsStation {
         )
     }
 
-    func nextTrains(at station: Station, key: String, session: URLSession) -> AnyPublisher<RailPredictions, WMATAError> {
+    func nextTrainsPublisher(at station: Station, key: String, session: URLSession) -> AnyPublisher<RailPredictions, WMATAError> {
         publisher(
             request: URLRequest(url: "\(RailURL.nextTrains.rawValue)\(station)", key: key),
             session: session
         )
     }
 
-    func nextTrains(at stations: [Station], key: String, session: URLSession) -> AnyPublisher<RailPredictions, WMATAError> {
+    func nextTrainsPublisher(at stations: [Station], key: String, session: URLSession) -> AnyPublisher<RailPredictions, WMATAError> {
         var urlArray = [RailURL.nextTrains.rawValue]
         urlArray.append(contentsOf: stations.map { $0.rawValue })
 
@@ -276,21 +276,21 @@ extension NeedsStation {
         )
     }
 
-    func information(for station: Station, key: String, session: URLSession) -> AnyPublisher<StationInformation, WMATAError> {
+    func informationPublisher(for station: Station, key: String, session: URLSession) -> AnyPublisher<StationInformation, WMATAError> {
         publisher(
             request: URLRequest(url: RailURL.information.rawValue, key: key, queryItems: [("StationCode", station.rawValue)]),
             session: session
         )
     }
 
-    func parkingInformation(for station: Station, key: String, session: URLSession) -> AnyPublisher<StationsParking, WMATAError> {
+    func parkingInformationPublisher(for station: Station, key: String, session: URLSession) -> AnyPublisher<StationsParking, WMATAError> {
         publisher(
             request: URLRequest(url: RailURL.parkingInformation.rawValue, key: key, queryItems: [("StationCode", station.rawValue)]),
             session: session
         )
     }
 
-    func path(from startingStation: Station, to destinationStation: Station, key: String, session: URLSession) -> AnyPublisher<PathBetweenStations, WMATAError> {
+    func pathPublisher(from startingStation: Station, to destinationStation: Station, key: String, session: URLSession) -> AnyPublisher<PathBetweenStations, WMATAError> {
         publisher(
             request: URLRequest(
                 url: RailURL.path.rawValue,
@@ -304,7 +304,7 @@ extension NeedsStation {
         )
     }
 
-    func timings(for station: Station, key: String, session: URLSession) -> AnyPublisher<StationTimings, WMATAError> {
+    func timingsPublisher(for station: Station, key: String, session: URLSession) -> AnyPublisher<StationTimings, WMATAError> {
         publisher(
             request: URLRequest(url: RailURL.timings.rawValue, key: key, queryItems: [("StationCode", station.rawValue)]),
             session: session
@@ -345,7 +345,7 @@ extension NeedsLine {
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension NeedsLine {
-    func stations(for line: Line?, key: String, session: URLSession) -> AnyPublisher<Stations, WMATAError> {
+    func stationsPublisher(for line: Line?, key: String, session: URLSession) -> AnyPublisher<Stations, WMATAError> {
         var queryItems = [(String, String)]()
 
         if let line = line {

--- a/Sources/WMATA/Rail/Stations.swift
+++ b/Sources/WMATA/Rail/Stations.swift
@@ -196,7 +196,7 @@ public extension Station {
     /// - Parameter session: Optional. URL Session to make this request with
     /// - returns: A Combine Publisher for `StationToStationInfos`
     func stationPublisher(to destinationStation: Station?, key: String, session: URLSession = URLSession.shared) -> AnyPublisher<StationToStationInfos, WMATAError> {
-        (self as NeedsStation).station(self, to: destinationStation, key: key, session: session)
+        (self as NeedsStation).stationPublisher(self, to: destinationStation, key: key, session: session)
     }
 
     /// Reported elevator and escalator incidents at this Station
@@ -204,7 +204,7 @@ public extension Station {
     /// - Parameter session: Optional. URL Session to make this request with
     /// - returns: A Combine Publisher for `ElevatorAndEscalatorIncidents`
     func elevatorAndEscalatorIncidentsPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<ElevatorAndEscalatorIncidents, WMATAError> {
-        (self as NeedsStation).elevatorAndEscalatorIncidents(at: self, key: key, session: session)
+        (self as NeedsStation).elevatorAndEscalatorIncidentsPublisher(at: self, key: key, session: session)
     }
 
     /// Reported MetroRail incidents at this Station
@@ -212,7 +212,7 @@ public extension Station {
     /// - Parameter session: Optional. URL Session to make this request with
     /// - returns: A Combine Publisher for `RailIncidents`
     func incidentsPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<RailIncidents, WMATAError> {
-        (self as NeedsStation).incidents(at: self, key: key, session: session)
+        (self as NeedsStation).incidentsPublisher(at: self, key: key, session: session)
     }
 
     ///  Next train arrival information for this Station
@@ -220,7 +220,7 @@ public extension Station {
     /// - Parameter session: Optional. URL Session to make this request with
     /// - returns: A Combine Publisher for  `RailPredictions`
     func nextTrainsPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<RailPredictions, WMATAError> {
-        (self as NeedsStation).nextTrains(at: self, key: key, session: session)
+        (self as NeedsStation).nextTrainsPublisher(at: self, key: key, session: session)
     }
 
     /// Location and address information for this Station
@@ -228,7 +228,7 @@ public extension Station {
     /// - Parameter session: Optional. URL Session to make this request with
     /// - returns: A Combine Publisher for `StationInformation`
     func informationPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<StationInformation, WMATAError> {
-        (self as NeedsStation).information(for: self, key: key, session: session)
+        (self as NeedsStation).informationPublisher(for: self, key: key, session: session)
     }
 
     /// Parking information for this Station
@@ -236,7 +236,7 @@ public extension Station {
     /// - Parameter session: Optional. URL Session to make this request with
     /// - returns: A Combine Publisher for `StationsParking`
     func parkingInformationPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<StationsParking, WMATAError> {
-        (self as NeedsStation).parkingInformation(for: self, key: key, session: session)
+        (self as NeedsStation).parkingInformationPublisher(for: self, key: key, session: session)
     }
 
     /// Returns a set of ordered stations and distances from this Station to another Station _on the same line_
@@ -245,7 +245,7 @@ public extension Station {
     /// - Parameter session: Optional. URL Session to make this request with
     /// - returns: A Combine Publisher for `PathBetweenStations`
     func pathPublisher(to destinationStation: Station, key: String, session: URLSession = URLSession.shared) -> AnyPublisher<PathBetweenStations, WMATAError> {
-        (self as NeedsStation).path(from: self, to: destinationStation, key: key, session: session)
+        (self as NeedsStation).pathPublisher(from: self, to: destinationStation, key: key, session: session)
     }
 
     /// Opening and scheduled first and last trains for this Station
@@ -253,7 +253,7 @@ public extension Station {
     /// - Parameter session: Optional. URL Session to make this request with
     /// - returns: A Combine Publisher for `StationTimings`
     func timingsPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<StationTimings, WMATAError> {
-        (self as NeedsStation).timings(for: self, key: key, session: session)
+        (self as NeedsStation).timingsPublisher(for: self, key: key, session: session)
     }
 }
 

--- a/Tests/WMATATests/WMATATests.swift
+++ b/Tests/WMATATests/WMATATests.swift
@@ -1484,6 +1484,7 @@ final class BusTests: XCTestCase {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 class CombineTests: XCTestCase {
     // Thanks to eskimo for this solution
     // https://developer.apple.com/forums/thread/121814?answerId=378975022#378975022
@@ -1498,6 +1499,7 @@ class CombineTests: XCTestCase {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 final class RailCombineTests: CombineTests {
     func testLinesPublisher() {
         let exp = expectation(description: #function)
@@ -1914,6 +1916,7 @@ final class RailCombineTests: CombineTests {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 final class BusCombineTests: CombineTests {
     func testPositionsPublisher() {
         let exp = expectation(description: #function)


### PR DESCRIPTION
Some platforms and Swift version 5.1 and 5.2 have issues disambiguating the publisher functions and delegate functions. Rename to make them unique