### PR TITLE
v10: Docs, Ergonomics, Bug Fixes

### DIFF
--- a/Documentation/v10 Migration Guide.md
+++ b/Documentation/v10 Migration Guide.md
@@ -1,0 +1,36 @@
+#  Migration to v10
+
+## Breaking changes
+
+- `Route` now encodes to a single value again rather than an object.  If you have previously saved documents using v9 containing a `Route`, you'll need to re-encode them. For example, with a JSONEncoder
+Prior to v9
+```javascript
+    "route": "10A"
+```
+
+v9
+```javascript
+    "route": {
+        "id": "10A"
+    }
+```
+
+v10
+```javascript
+    "route"": "10A"
+```
+
+-`Stop` now encodes to a single value. If you have previously saved documents containing a `Stop`, you'll need to re-encode them. For example with JSONEncoder
+Prior to v10
+```javascript
+    "stop": {
+        "id": "1234567"
+    }
+```
+
+v10
+```javascript
+    "stop": "1234567"
+```
+
+- `StopInfo`'s `time` field now decodes to a `Date` rather than a `String`.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ WMATA.swift is a Swift interface to the [Washington Metropolitan Area Transit Au
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/emma-k-alexandra/WMATA.swift.git", .upToNextMajor(from: "9.0.0"))
+    .package(url: "https://github.com/emma-k-alexandra/WMATA.swift.git", .upToNextMajor(from: "10.0.0"))
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ dependencies: [
 ## Migration Guides
 
 - [v9 Migration Guide][v9-migration-guide]
+- [v10 Migration Guide][v10-migration-guide]
 
 ## Dependencies
 
@@ -82,6 +83,7 @@ WMATA.swift is released under the MIT license. [See LICENSE](https://github.com/
 [radius-at-coordinates]: https://github.com/emma-k-alexandra/WMATA.swift/blob/master/Documentation/Miscellaneous.md#RadiusAtCoordinates
 [wmata-date]: https://github.com/emma-k-alexandra/WMATA.swift/blob/master/Documentation/Miscellaneous.md#WMATADate
 [v9-migration-guide]: https://github.com/emma-k-alexandra/WMATA.swift/blob/master/Documentation/v9%20Migration%20Guide.md
+[v10-migration-guide]: https://github.com/emma-k-alexandra/WMATA.swift/blob/master/Documentation/v10%20Migration%20Guide.md
 [gtfs]: https://github.com/emma-k-alexandra/GTFS
 [swift-protobuf]: https://github.com/apple/swift-protobuf
 [wmata]: https://developer.wmata.com

--- a/Sources/WMATA/Bus/BusResponses.swift
+++ b/Sources/WMATA/Bus/BusResponses.swift
@@ -474,24 +474,35 @@ public struct StopResponse: Codable {
     }
 }
 
-
+/// Response from the [Routes API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6a)
 /// - Tag: RoutesResponse
 public struct RoutesResponse: Codable {
+    /// List of routes
     public let routes: [RouteResponse]
 
     enum CodingKeys: String, CodingKey {
         case routes = "Routes"
     }
 
+    /// Create a routes response
+    ///
+    /// - Parameters:
+    ///     - routes: List of routes
     public init(routes: [RouteResponse]) {
         self.routes = routes
     }
 }
 
+/// Response from the [Routes API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6a)
 /// - Tag: RouteResponse
 public struct RouteResponse: Codable {
+    /// Unique identifier for a given route variant. Can be used in various other bus-related methods.
     public let route: Route
+    
+    /// Descriptive name of the route variant.
     public let name: String
+    
+    /// Denotes the route variant’s grouping – lines are a combination of routes which lie in the same corridor and which have significant portions of their paths along the same roadways.
     public let lineDescription: String
 
     enum CodingKeys: String, CodingKey {
@@ -500,6 +511,12 @@ public struct RouteResponse: Codable {
         case lineDescription = "LineDescription"
     }
 
+    /// Create a route response
+    ///
+    /// - Parameters:
+    ///     - route: Route identifier
+    ///     - name: Name of the route variant
+    ///     - lineDescription: Route variant's grouping
     public init(
         route: Route,
         name: String,
@@ -519,9 +536,13 @@ public struct RouteResponse: Codable {
     }
 }
 
+/// Response from the [Schedule at Stop API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6c)
 /// - Tag: StopSchedule
 public struct StopSchedule: Codable {
+    /// Arrivals at this stop
     public let arrivals: [BusArrival]
+    
+    /// Stop information
     public let stop: StopScheduleResponse
 
     enum CodingKeys: String, CodingKey {
@@ -529,6 +550,11 @@ public struct StopSchedule: Codable {
         case stop = "Stop"
     }
 
+    /// Create a stop schedule
+    ///
+    /// - Parameters:
+    ///     - arrivals: Arrivals at this stop
+    ///     - stop: Stop information
     public init(
         arrivals: [BusArrival],
         stop: StopScheduleResponse
@@ -538,15 +564,31 @@ public struct StopSchedule: Codable {
     }
 }
 
+/// Response from the [Schedule at Stop API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6c)
 /// - Tag: BusArrival
 public struct BusArrival: Codable {
+    /// Date and time (Eastern Standard Time) when the bus is scheduled to stop at this location.
     public let scheduleTime: Date
+    
+    /// Denotes a binary direction (0 or 1) of the bus. There is no specific mapping to direction, but a different value for the same route signifies that the buses are traveling in opposite directions. Use the tripDirectionText element to show the actual destination of the bus.
     public let directionNumber: String
+    
+    /// Scheduled start date and time (Eastern Standard Time) for this trip.
     public let startTime: Date
+    
+    /// Scheduled end date and time (Eastern Standard Time) for this trip.
     public let endTime: Date
+    
+    /// Bus route variant identifier (pattern). This variant can be used in several other bus methods which accept variants. Note that customers will never see anything other than the base route name, so variants 10A, 10Av1, 10Av2, etc. will be displayed as 10A on the bus.
     public let route: Route
+    
+    /// General direction of the trip (e.g.: NORTH, SOUTH, EAST, WEST).
     public let tripDirectionText: String
+    
+    /// Destination of the bus.
     public let tripHeadsign: String
+    
+    /// Trip identifier. This can be correlated with the data in our bus schedule information as well as bus positions.
     public let tripId: String
 
     enum CodingKeys: String, CodingKey {
@@ -560,6 +602,17 @@ public struct BusArrival: Codable {
         case tripId = "TripID"
     }
 
+    /// Create a bus arrival
+    ///
+    /// - Parameters:
+    ///     - scheduleTime: Time the bus is schedule to arrive at this stop
+    ///     - directionNumber: 0 to 1, as a String
+    ///     - startTime: Start time of this trip
+    ///     - endTime: End time of this trip
+    ///     - route: Route variant
+    ///     - tripDirectionText: General direction of bus
+    ///     - tripHeadsign: Destination of bus
+    ///     - tripId: Trip Identifier
     public init(
         scheduleTime: Date,
         directionNumber: String,
@@ -608,12 +661,23 @@ public struct BusArrival: Codable {
     }
 }
 
+/// Response from the [Schedule at Stop API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6c),
+/// Response from the [Stop Search API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6d)
 /// - Tag: StopScheduleResponse
 public struct StopScheduleResponse: Codable {
+    /// 7-digit regional ID which can be used in various bus-related methods. If unavailable, the StopID will be 0 or NULL.
     public let stop: Stop?
+    
+    /// Stop name. May be slightly different from what is spoken or displayed in the bus.
     public let name: String
+    
+    /// Latitude of stop.
     public let latitude: Double
+    
+    /// Longitude of stop.
     public let longitude: Double
+    
+    /// Array of route variants which provide service at this stop. Note that these are not date-specific; any route variant which stops at this stop on any day will be listed.
     public let routes: [Route]
 
     enum CodingKeys: String, CodingKey {
@@ -624,6 +688,14 @@ public struct StopScheduleResponse: Codable {
         case routes = "Routes"
     }
 
+    /// Create a stop schedule response
+    ///
+    /// - Parameters:
+    ///     - stop: Stop ID
+    ///     - name: Stop name
+    ///     - latitude: Latitude of stop
+    ///     - longitude: Longitude of stop
+    ///     - routes: Routes that service this stop
     public init(
         stop: Stop?,
         name: String,
@@ -670,38 +742,60 @@ public struct StopScheduleResponse: Codable {
     }
 }
 
+/// Response from the [Stop Search API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6d)
 /// - Tag: StopsSearchResponse
 public struct StopsSearchResponse: Codable {
+    /// List of stop schedules
     public let stops: [StopScheduleResponse]
 
     enum CodingKeys: String, CodingKey {
         case stops = "Stops"
     }
-
+    
+    /// Create a stop search response
+    ///
+    /// - Parameters:
+    ///     - stops: Stop schedules
     public init(stops: [StopScheduleResponse]) {
         self.stops = stops
     }
 }
 
+/// Response from the [Bus Incidents API](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d75)
 /// - Tag: BusIncidents
 public struct BusIncidents: Codable {
+    /// List of incidents
     public let incidents: [BusIncident]
 
     enum CodingKeys: String, CodingKey {
         case incidents = "BusIncidents"
     }
 
+    /// Create a bus incidents response
+    ///
+    /// - Parameters:
+    ///     - incidents: List of incidents
     public init(incidents: [BusIncident]) {
         self.incidents = incidents
     }
 }
 
+/// Response from the [Bus Incidents API](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d75)
 /// - Tag: BusIncident
 public struct BusIncident: Codable {
+    /// Date and time (Eastern Standard Time) of last update.
     public let dateUpdated: String
+    
+    /// Free-text description of the delay or incident.
     public let description: String
+    
+    /// Unique identifier for an incident.
     public let incidentId: String
+    
+    /// Free-text description of the incident type. Usually Delay or Alert but is subject to change at any time.
     public let incidentType: String
+    
+    /// Array containing routes affected. Routes listed are usually identical to base route names (i.e.: not 10Av1 or 10Av2, but 10A), but may differ from what our bus methods return.
     public let routesAffected: [Route]
 
     enum CodingKeys: String, CodingKey {
@@ -712,6 +806,14 @@ public struct BusIncident: Codable {
         case routesAffected = "RoutesAffected"
     }
 
+    /// Create a bus incident response
+    ///
+    /// - Parameters:
+    ///     - dateUpdated: Time of last status update
+    ///     - description: Description of incident
+    ///     - incidentId: Unique ID of incident
+    ///     - incidentType: Description of incident type
+    ///     - routesAffected: List of routes affected
     public init(
         dateUpdated: String,
         description: String,
@@ -740,10 +842,24 @@ public struct BusIncident: Codable {
     }
 }
 
+/// Response from the [Schedule API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6b)
 /// - Tag: RouteSchedule
 public struct RouteSchedule: Codable {
+    /// Descriptive name for the route.
     public let name: String
+    
+    /// Arrays containing trip information.
+    ///
+    /// Most routes will return content in both Direction0 and Direction1 elements, though a few (especially ones which run in a loop, such as the U8) will return content only for Direction0 and NULL content for Direction1.
+    ///
+    /// 0 or 1 are binary properties. There is no specific mapping to direction, but a different value for the same route signifies that the route is in an opposite direction.
     public let directionZero: [RouteInfo]
+    
+    /// Arrays containing trip information.
+    ///
+    /// Most routes will return content in both Direction0 and Direction1 elements, though a few (especially ones which run in a loop, such as the U8) will return content only for Direction0 and NULL content for Direction1.
+    ///
+    /// 0 or 1 are binary properties. There is no specific mapping to direction, but a different value for the same route signifies that the route is in an opposite direction.
     public let directionOne: [RouteInfo]
 
     enum CodingKeys: String, CodingKey {
@@ -752,6 +868,12 @@ public struct RouteSchedule: Codable {
         case directionOne = "Direction1"
     }
 
+    /// Create a route schedule response
+    ///
+    /// - Parameters:
+    ///     - name: Name of route
+    ///     - directionZero: List of route info
+    ///     - directionOne: List of route info
     public init(
         name: String,
         directionZero: [RouteInfo],
@@ -763,15 +885,31 @@ public struct RouteSchedule: Codable {
     }
 }
 
+/// Response from the [Schedule API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6b)
 /// - Tag: RouteInfo
 public struct RouteInfo: Codable {
+    /// Bus route variant. This can be used in several other bus methods which accept variants.
     public let route: Route
+    
+    /// Warning: Deprecated. Use the TripDirectionText element to denote the general direction of the trip.
     public let directionNumber: String
+    
+    /// General direction of the trip (NORTH, SOUTH, EAST, WEST, LOOP, etc.).
     public let tripDirectionText: String
+    
+    /// Descriptive text of where the bus is headed. This is similar, but not necessarily identical, to what is displayed on the bus.
     public let tripHeadsign: String
+    
+    /// Scheduled start date and time (Eastern Standard Time) for this trip.
     public let startTime: Date
+    
+    /// Scheduled end date and time (Eastern Standard Time) for this trip.
     public let endTime: Date
+    
+    /// List of location and time information
     public let stopTimes: [StopInfo]
+    
+    /// Unique trip ID. This can be correlated with the data returned from the schedule-related methods.
     public let tripId: String
 
     enum CodingKeys: String, CodingKey {
@@ -785,6 +923,17 @@ public struct RouteInfo: Codable {
         case tripId = "TripID"
     }
 
+    /// Create a route info response
+    ///
+    /// - Parameters:
+    ///     - route: Route ID
+    ///     - directionNumber: Deprecated. Direction of route
+    ///     - tripDirectionText: General direction of trip
+    ///     - tripHeadsign: Destination of route
+    ///     - startTime: Start time of trip
+    ///     - endTime: End time of trip
+    ///     - stopTimes: List of location and time information
+    ///     - tripId: Unique trip ID
     public init(
         route: Route,
         directionNumber: String,
@@ -832,12 +981,20 @@ public struct RouteInfo: Codable {
     }
 }
 
+/// Response from the [Schedule API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6b)
 /// - Tag: StopInfo
 public struct StopInfo: Codable {
+    /// 7-digit regional ID which can be used in various bus-related methods. If unavailable, the StopID will be 0 or NULL.
     public let stop: Stop
+    
+    /// Stop name. May be slightly different from what is spoken or displayed in the bus.
     public let stopName: String
+    
+    /// Order of the stop in the sequence
     public let stopSequence: Int
-    public let time: String
+    
+    /// Scheduled departure date and time (Eastern Standard Time) from this stop.
+    public let time: Date
 
     enum CodingKeys: String, CodingKey {
         case stop = "StopID"
@@ -846,11 +1003,18 @@ public struct StopInfo: Codable {
         case time = "Time"
     }
 
+    /// Create a stop info response
+    ///
+    /// - Parameters:
+    ///     - stop: Stop ID
+    ///     - stopName: Name of stop
+    ///     - stopSequence: Order of the stop in sequence
+    ///     - time: Scheduled departure time from this stop
     public init(
         stop: Stop,
         stopName: String,
         stopSequence: Int,
-        time: String
+        time: Date
     ) {
         self.stop = stop
         self.stopName = stopName
@@ -864,7 +1028,7 @@ public struct StopInfo: Codable {
         stop = Stop(id: try container.decode(String.self, forKey: .stop))
         stopName = try container.decode(String.self, forKey: .stopName)
         stopSequence = try container.decode(Int.self, forKey: .stopSequence)
-        time = try container.decode(String.self, forKey: .time)
+        time = try (try container.decode(String.self, forKey: .time)).toWMATADate()
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -873,6 +1037,6 @@ public struct StopInfo: Codable {
         try container.encode(stop.description, forKey: .stop)
         try container.encode(stopName, forKey: .stopName)
         try container.encode(stopSequence, forKey: .stopSequence)
-        try container.encode(time, forKey: .time)
+        try container.encode(time.toWMATAString(), forKey: .time)
     }
 }

--- a/Sources/WMATA/Bus/BusResponses.swift
+++ b/Sources/WMATA/Bus/BusResponses.swift
@@ -359,6 +359,7 @@ public struct RouteResponse: Codable {
     }
 }
 
+/// - Tag: StopSchedule
 public struct StopSchedule: Codable {
     public let arrivals: [BusArrival]
     public let stop: StopScheduleResponse

--- a/Sources/WMATA/Bus/BusResponses.swift
+++ b/Sources/WMATA/Bus/BusResponses.swift
@@ -7,24 +7,49 @@
 
 import Foundation
 
+/// Response from the [Next Buses API](https://developer.wmata.com/docs/services/5476365e031f590f38092508/operations/5476365e031f5909e4fe331d)
+/// - Tag: BusPredictions
 public struct BusPredictions: Codable {
+    /// List of predictions
     public let predictions: [BusPrediction]
+    
+    /// The full name from the given stop
+    public let stopName: String
 
     enum CodingKeys: String, CodingKey {
         case predictions = "Predictions"
+        case stopName = "StopName"
     }
-
-    public init(predictions: [BusPrediction]) {
+    
+    /// Create a new response
+    ///
+    /// - Parameters:
+    ///     - predictions: A list of predictions
+    public init(predictions: [BusPrediction], stopName: String) {
         self.predictions = predictions
+        self.stopName = stopName
     }
 }
 
+/// Response from the [Next Buses API](https://developer.wmata.com/docs/services/5476365e031f590f38092508/operations/5476365e031f5909e4fe331d)
+/// - Tag: BusPrediction
 public struct BusPrediction: Codable {
+    /// Denotes a binary direction (0 or 1) of the bus. There is no specific mapping to direction, but a different value for the same route signifies that the buses are traveling in opposite directions. Use the DirectionText element to show the actual destination of the bus.
     public let directionNumber: String
+    
+    /// Customer-friendly description of direction and destination for a bus.
     public let directionText: String
+    
+    /// Minutes until bus arrival at this stop.
     public let minutes: Int
+    
+    /// Route ID of the bus. Base route name as shown on the bus. This can be used in other bus-related methods. Note that all variants will be shown as their base route names (i.e.: 10Av1 and 10Av2 will be shown as 10A).
     public let route: Route
+    
+    /// Trip identifier. This can be correlated with the data in our bus schedule information as well as bus positions.
     public let tripId: String
+    
+    /// Bus identifier. This can be correlated with results returned from bus positions.
     public let vehicleId: String
 
     enum CodingKeys: String, CodingKey {
@@ -36,6 +61,15 @@ public struct BusPrediction: Codable {
         case vehicleId = "VehicleID"
     }
 
+    /// Create a prediction
+    ///
+    /// - Parameters:
+    ///     - directionNumber: Direction of the bus
+    ///     - directionText: Customer friend description of direction and destination of bus
+    ///     - minutes: Time until arrival at this stop
+    ///     - route: Route ID of the bus
+    ///     - tripId: Trip ID of this bus
+    ///     - vehicleId: Unique vehicle identifier
     public init(
         directionNumber: String,
         directionText: String,
@@ -76,31 +110,65 @@ public struct BusPrediction: Codable {
     }
 }
 
+/// Response from the [Bus Position API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d68)
+/// - Tag: BusPositions
 public struct BusPositions: Codable {
+    /// List of bus positions
     public let busPositions: [BusPosition]
 
     enum CodingKeys: String, CodingKey {
         case busPositions = "BusPositions"
     }
 
+    /// Create a bus position response
+    ///
+    /// - Parameters:
+    ///     - busPositions: List of bus positions
     public init(busPositions: [BusPosition]) {
         self.busPositions = busPositions
     }
 }
 
+/// Response from the [Bus Position API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d68)
+/// - Tag: BusPosition
 public struct BusPosition: Codable {
+    /// Date and time (Eastern Standard Time) of last position update.
     public let dateTime: Date
+    
+    /// Deviation, in minutes, from schedule. Positive values indicate that the bus is running late while negative ones are for buses running ahead of schedule.
     public let deviation: Double
+    
+    /// Deprecated. Use the DirectionText for a customer-friendly description of direction.
     public let directionNumber: Int
+    
+    /// General direction of the trip, not the bus itself (e.g.: NORTH, SOUTH, EAST, WEST).
     public let directionText: String
+    
+    /// Latitude of bus.
     public let latitude: Double
+    
+    /// Longitude of bus.
     public let longitude: Double
+    
+    /// Base route name as shown on the bus. Note that the base route name could also refer to any variant, so a RouteID of 10A could refer to 10A, 10Av1, 10Av2, etc.
     public let route: Route
+    
+    /// Scheduled end date and time (Eastern Standard Time) of the bus's current trip.
     public let tripEndTime: Date
+    
+    /// Destination of the bus.
     public let tripHeadsign: String
+    
+    /// Unique trip ID. This can be correlated with the data returned from the schedule-related methods.
     public let tripId: String
+    
+    /// Scheduled start date and time (Eastern Standard Time) of the bus's current trip.
     public let tripStartTime: Date
+    
+    /// Unique identifier for the bus. This is usually visible on the bus itself.
     public let vehicleId: String
+    
+    /// Undocumented by WMATA
     public let blockNumber: String
 
     enum CodingKeys: String, CodingKey {
@@ -119,6 +187,22 @@ public struct BusPosition: Codable {
         case blockNumber = "BlockNumber"
     }
 
+    /// Create a bus position
+    ///
+    /// - Parameters:
+    ///     - dateTime: Time of last position update
+    ///     - deviation: Deviation in minutes from schedule
+    ///     - directionNumber: Deprecated. Use directionText
+    ///     - directionText: General direction of trip
+    ///     - latitude: Latitude of bus
+    ///     - longitude: Longitude of bus
+    ///     - route: Route ID of this bus
+    ///     - tripEndTime: Scheduled end of this trip
+    ///     - tripHeadsign: Destination of bus
+    ///     - tripId: Unique trip ID
+    ///     - tripStartTime: Schedule start time of this trip
+    ///     - vehicleId: Unique id for this vehicle
+    ///     - blockNumber: Undocumented by WMATA
     public init(
         dateTime: Date,
         deviation: Double,
@@ -186,10 +270,24 @@ public struct BusPosition: Codable {
     }
 }
 
+/// Response from the [Path Details API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d69)
+/// - Tag: PathDetails
 public struct PathDetails: Codable {
+    
+    /// Bus route variant
     public let routeId: String
+    
+    /// Descriptive name for the route.
     public let name: String
+    
+    /// Structures describing path/stop information.
+    /// Most routes will return content in both Direction0 and Direction1 elements, though a few will return NULL for Direction0 or for Direction1.
+    /// 0 or 1 are binary properties. There is no specific mapping to direction, but a different value for the same route signifies that the route is in an opposite direction.
     public let directionZero: PathDirection
+    
+    /// Structures describing path/stop information.
+    /// Most routes will return content in both Direction0 and Direction1 elements, though a few will return NULL for Direction0 or for Direction1.
+    /// 0 or 1 are binary properties. There is no specific mapping to direction, but a different value for the same route signifies that the route is in an opposite direction.
     public let directionOne: PathDirection
 
     enum CodingKeys: String, CodingKey {
@@ -199,6 +297,13 @@ public struct PathDetails: Codable {
         case directionOne = "Direction1"
     }
 
+    /// Create path details
+    ///
+    /// - Parameters:
+    ///     - routeId: Bus route variant
+    ///     - name: Name of the route
+    ///     - directionZero: Path information
+    ///     - directionOne: Path information
     public init(
         routeId: String,
         name: String,
@@ -212,11 +317,23 @@ public struct PathDetails: Codable {
     }
 }
 
+/// Structures describing path/stop information. From the [Path Details API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d69)
+/// - Tag: PathDirection
 public struct PathDirection: Codable {
+    
+    /// Descriptive text of where the bus is headed. This is similar, but not necessarily identical, to what is displayed on the bus.
     public let tripHeadsign: String
+    
+    /// General direction of the route variant (NORTH, SOUTH, EAST, WEST, LOOP, etc.).
     public let directionText: String
+    
+    /// Warning: Deprecated. Use the DirectionText element to denote the general direction of the route variant.
     public let directionNumber: String
+    
+    /// Array containing shape point information. See  [PathStop](x-source-tag://PathStop)
     public let shape: [PathStop]
+    
+    /// Array containing stop information. See [StopResponse](x-source-tag://StopResponse)
     public let stops: [StopResponse]
 
     enum CodingKeys: String, CodingKey {
@@ -227,6 +344,14 @@ public struct PathDirection: Codable {
         case stops = "Stops"
     }
 
+    /// Create a path direction
+    ///
+    /// - Parameters:
+    ///     - tripHeadsign: Description of where the bus is headed
+    ///     - directionText: General direction of route
+    ///     - directionNumber: Deprecated. Use directionText
+    ///     - shape: Shape point information
+    ///     - stops: Stop information
     public init(
         tripHeadsign: String,
         directionText: String,
@@ -242,9 +367,16 @@ public struct PathDirection: Codable {
     }
 }
 
+/// Shape point information. From the [Path Details API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d69)
+/// - Tag: PathStop
 public struct PathStop: Codable {
+    /// Latitude of stop.
     public let latitude: Double
+    
+    /// Longitude of stop.
     public let longitude: Double
+    
+    /// Order of the point in the sequence of PathStop.
     public let sequenceNumber: Int
 
     enum CodingKeys: String, CodingKey {
@@ -253,6 +385,12 @@ public struct PathStop: Codable {
         case sequenceNumber = "SeqNum"
     }
 
+    /// Create a path stop
+    ///
+    /// - Parameters:
+    ///     - latitude: Latitude of stop
+    ///     - longitude: Longitude of stop
+    ///     - sequenceNumber: Index of this point
     public init(
         latitude: Double,
         longitude: Double,
@@ -264,11 +402,22 @@ public struct PathStop: Codable {
     }
 }
 
+/// Stop information. From the [Path Details API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d69)
+/// - Tag: StopResponse
 public struct StopResponse: Codable {
+    /// 7-digit regional ID which can be used in various bus-related methods.
     public let stop: Stop
+    
+    /// Stop name. May be slightly different from what is spoken or displayed in the bus.
     public let name: String
+    
+    /// Latitude of stop.
     public let latitude: Double
+    
+    /// Longitude of stop.
     public let longitude: Double
+    
+    /// Array of route variants which provide service at this stop. Note that these are not date-specific; any route variant which stops at this stop on any day will be listed.
     public let routes: [Route]
 
     enum CodingKeys: String, CodingKey {
@@ -279,6 +428,14 @@ public struct StopResponse: Codable {
         case routes = "Routes"
     }
 
+    /// Create a Stop response
+    ///
+    /// - Parameters:
+    ///     - stop: Stop ID of the stop
+    ///     - name: Name of stop
+    ///     - latitude: latitude of stop
+    ///     - longitude: longitude of stop
+    ///     - routes: Routes that provide service to this stop
     public init(
         stop: Stop,
         name: String,
@@ -317,6 +474,8 @@ public struct StopResponse: Codable {
     }
 }
 
+
+/// - Tag: RoutesResponse
 public struct RoutesResponse: Codable {
     public let routes: [RouteResponse]
 
@@ -329,6 +488,7 @@ public struct RoutesResponse: Codable {
     }
 }
 
+/// - Tag: RouteResponse
 public struct RouteResponse: Codable {
     public let route: Route
     public let name: String
@@ -378,6 +538,7 @@ public struct StopSchedule: Codable {
     }
 }
 
+/// - Tag: BusArrival
 public struct BusArrival: Codable {
     public let scheduleTime: Date
     public let directionNumber: String
@@ -447,6 +608,7 @@ public struct BusArrival: Codable {
     }
 }
 
+/// - Tag: StopScheduleResponse
 public struct StopScheduleResponse: Codable {
     public let stop: Stop?
     public let name: String
@@ -508,6 +670,7 @@ public struct StopScheduleResponse: Codable {
     }
 }
 
+/// - Tag: StopsSearchResponse
 public struct StopsSearchResponse: Codable {
     public let stops: [StopScheduleResponse]
 
@@ -520,6 +683,7 @@ public struct StopsSearchResponse: Codable {
     }
 }
 
+/// - Tag: BusIncidents
 public struct BusIncidents: Codable {
     public let incidents: [BusIncident]
 
@@ -532,6 +696,7 @@ public struct BusIncidents: Codable {
     }
 }
 
+/// - Tag: BusIncident
 public struct BusIncident: Codable {
     public let dateUpdated: String
     public let description: String
@@ -575,6 +740,7 @@ public struct BusIncident: Codable {
     }
 }
 
+/// - Tag: RouteSchedule
 public struct RouteSchedule: Codable {
     public let name: String
     public let directionZero: [RouteInfo]
@@ -597,6 +763,7 @@ public struct RouteSchedule: Codable {
     }
 }
 
+/// - Tag: RouteInfo
 public struct RouteInfo: Codable {
     public let route: Route
     public let directionNumber: String
@@ -665,6 +832,7 @@ public struct RouteInfo: Codable {
     }
 }
 
+/// - Tag: StopInfo
 public struct StopInfo: Codable {
     public let stop: Stop
     public let stopName: String

--- a/Sources/WMATA/Bus/Routes.swift
+++ b/Sources/WMATA/Bus/Routes.swift
@@ -8,9 +8,15 @@
 import Combine
 import Foundation
 
+/// A WMATA Route ID
 public struct Route: Codable {
+    /// A WMATA Route ID
     public let id: String
 
+    /// Create a Route ID
+    ///
+    /// - Parameters:
+    ///     - id: A Route ID
     public init(id: String) {
         self.id = id
     }
@@ -27,38 +33,49 @@ extension Route: NeedsRoute {}
 public extension Route {
     /// Bus positions on this Route including latlong and direction.
     ///
-    /// - Parameter radiusAtCoordinates: Radius at latlong to search at
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - Parameter completion: completion handler which returns `BusPositions`
-    func positions(at radiusAtCoordinates: RadiusAtCoordinates?, key: String, session: URLSession = URLSession.shared, completion: @escaping (Result<BusPositions, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - radiusAtCoordinates: Radius at latlong to search at
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///     - completion: A completion handler
+    ///     - result: [BusPositions](x-source-tag://BusPositions) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func positions(at radiusAtCoordinates: RadiusAtCoordinates?, key: String, session: URLSession = URLSession.shared, completion: @escaping (_ result: Result<BusPositions, WMATAError>) -> Void) {
         (self as NeedsRoute).positions(on: self, at: radiusAtCoordinates, key: key, session: session, completion: completion)
     }
 
     /// Bus incidents along this Route.
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - Parameter completion: completion handler which return `BusIncidents`
-    func incidents(key: String, session: URLSession = URLSession.shared, completion: @escaping (Result<BusIncidents, WMATAError>) -> Void) {
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///     - completion: completion handler which return `BusIncidents`
+    ///     - result: [BusIncidents](x-source-tag://BusIncidents) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func incidents(key: String, session: URLSession = URLSession.shared, completion: @escaping (_ result: Result<BusIncidents, WMATAError>) -> Void) {
         (self as NeedsRoute).incidents(on: self, key: key, session: session, completion: completion)
     }
 
     /// Ordered latlong points along this Route for a given date.
-    /// - Parameter date: `WMATADate`. nil for today.
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - Parameter completion: completion handler which returns `PathDetails`
-    func pathDetails(on date: WMATADate? = nil, key: String, session: URLSession = URLSession.shared, completion: @escaping (Result<PathDetails, WMATAError>) -> Void) {
+    ///
+    /// - Parameters:
+    ///     - date: Day to get details for. Omit for today
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///     - completion: A completion handler
+    ///     - result: [PathDetails](x-source-tag://PathDetails) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func pathDetails(on date: WMATADate? = nil, key: String, session: URLSession = URLSession.shared, completion: @escaping (_ result: Result<PathDetails, WMATAError>) -> Void) {
         (self as NeedsRoute).pathDetails(for: self, on: date, key: key, session: session, completion: completion)
     }
 
     /// Scheduled stops for this Route
-    /// - Parameter date: `WMATADate`. Omit for today.
-    /// - Parameter includingVariations: Whether to include route variations. Example: B30v1 and B30v2 for Route B30
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - Parameter completion: completion handler which returns `RoutesResponse`
-    func schedule(on date: WMATADate? = nil, includingVariations: Bool? = false, key: String, session: URLSession = URLSession.shared, completion: @escaping (Result<RouteSchedule, WMATAError>) -> Void) {
+    ///
+    /// - Parameters:
+    ///     - date: Day to get stops for. Omit for today.
+    ///     - includingVariations: Whether to include route variations. Example: B30v1 and B30v2 for Route B30
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///     - completion: A completion handler
+    ///     - result: [RouteSchedule](x-source-tag://RouteSchedule) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func schedule(on date: WMATADate? = nil, includingVariations: Bool? = false, key: String, session: URLSession = URLSession.shared, completion: @escaping (_ result: Result<RouteSchedule, WMATAError>) -> Void) {
         (self as NeedsRoute).schedule(for: self, on: date, includingVariations: includingVariations, key: key, session: session, completion: completion)
     }
 }
@@ -67,37 +84,48 @@ public extension Route {
 public extension Route {
     /// Bus positions on this Route including latlong and direction.
     ///
-    /// - Parameter radiusAtCoordinates: Radius at latlong to search at
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - returns: A Combine Publisher for `BusPositions`
+    /// - Parameters:
+    ///     - radiusAtCoordinates: Radius at latlong to search at
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///
+    /// - Returns: A Combine Publisher for [BusPositions](x-source-tag://BusPositions)
     func positionsPublisher(at radiusAtCoordinates: RadiusAtCoordinates?, key: String, session: URLSession = URLSession.shared) -> AnyPublisher<BusPositions, WMATAError> {
         (self as NeedsRoute).positionsPublisher(on: self, at: radiusAtCoordinates, key: key, session: session)
     }
 
     /// Bus incidents along this Route.
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - returns: A Combine Publisher for `BusIncidents`
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///
+    /// - Returns: A Combine Publisher for [BusIncidents](x-source-tag://BusIncidents)
     func incidentsPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<BusIncidents, WMATAError> {
         (self as NeedsRoute).incidentsPublisher(on: self, key: key, session: session)
     }
 
     /// Ordered latlong points along this Route for a given date.
-    /// - Parameter date: `WMATADate`. nil for today.
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - returns: A Combine Publisher for `PathDetails`
+    ///
+    /// - Parameters:
+    ///     - date: Day to get route. Omit for today.
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///
+    /// - Returns: A Combine Publisher for [PathDetails](x-source-tag://PathDetails)
     func pathDetailsPublisher(on date: WMATADate? = nil, key: String, session: URLSession = URLSession.shared) -> AnyPublisher<PathDetails, WMATAError> {
         (self as NeedsRoute).pathDetailsPublisher(for: self, on: date, key: key, session: session)
     }
 
     /// Scheduled stops for this Route
-    /// - Parameter date: `WMATADate`. Omit for today.
-    /// - Parameter includingVariations: Whether to include route variations. Example: B30v1 and B30v2 for Route B30
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - returns: A Combine Publisher for `RoutesResponse`
+    ///
+    /// - Parameters:
+    ///     - date: Day to get stops for`. Omit for today.
+    ///     - includingVariations: Whether to include route variations. Example: B30v1 and B30v2 for Route B30
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///
+    /// - Returns: A Combine Publisher for [RouteSchedule](x-source-tag://RouteSchedule)
     func schedulePublisher(on date: WMATADate? = nil, includingVariations: Bool? = false, key: String, session: URLSession = URLSession.shared) -> AnyPublisher<RouteSchedule, WMATAError> {
         (self as NeedsRoute).schedulePublisher(for: self, on: date, includingVariations: includingVariations, key: key, session: session)
     }

--- a/Sources/WMATA/Bus/Routes.swift
+++ b/Sources/WMATA/Bus/Routes.swift
@@ -20,6 +20,12 @@ public struct Route: Codable {
     public init(id: String) {
         self.id = id
     }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        
+        try container.encode(id)
+    }
 }
 
 extension Route: ExpressibleByStringLiteral {
@@ -39,7 +45,7 @@ public extension Route {
     ///     - session: Optional. URL Session to make this request with
     ///     - completion: A completion handler
     ///     - result: [BusPositions](x-source-tag://BusPositions) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
-    func positions(at radiusAtCoordinates: RadiusAtCoordinates?, key: String, session: URLSession = URLSession.shared, completion: @escaping (_ result: Result<BusPositions, WMATAError>) -> Void) {
+    func positions(at radiusAtCoordinates: RadiusAtCoordinates? = nil, key: String, session: URLSession = URLSession.shared, completion: @escaping (_ result: Result<BusPositions, WMATAError>) -> Void) {
         (self as NeedsRoute).positions(on: self, at: radiusAtCoordinates, key: key, session: session, completion: completion)
     }
 
@@ -90,7 +96,7 @@ public extension Route {
     ///     - session: Optional. URL Session to make this request with
     ///
     /// - Returns: A Combine Publisher for [BusPositions](x-source-tag://BusPositions)
-    func positionsPublisher(at radiusAtCoordinates: RadiusAtCoordinates?, key: String, session: URLSession = URLSession.shared) -> AnyPublisher<BusPositions, WMATAError> {
+    func positionsPublisher(at radiusAtCoordinates: RadiusAtCoordinates? = nil, key: String, session: URLSession = URLSession.shared) -> AnyPublisher<BusPositions, WMATAError> {
         (self as NeedsRoute).positionsPublisher(on: self, at: radiusAtCoordinates, key: key, session: session)
     }
 

--- a/Sources/WMATA/Bus/Routes.swift
+++ b/Sources/WMATA/Bus/Routes.swift
@@ -39,8 +39,11 @@ extension Route: NeedsRoute {}
 public extension Route {
     /// Bus positions on this Route including latlong and direction.
     ///
+    /// - Note:
+    ///     [WMATA Positions Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d68)
+    ///
     /// - Parameters:
-    ///     - radiusAtCoordinates: Radius at latlong to search at
+    ///     - radiusAtCoordinates: Radius at latlong to search at. Optional.
     ///     - key: WMATA API Key to use with this request
     ///     - session: Optional. URL Session to make this request with
     ///     - completion: A completion handler
@@ -50,6 +53,9 @@ public extension Route {
     }
 
     /// Bus incidents along this Route.
+    ///
+    /// - Note:
+    ///     [WMATA Incidents Documentation](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d75)
     ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request
@@ -61,6 +67,9 @@ public extension Route {
     }
 
     /// Ordered latlong points along this Route for a given date.
+    ///
+    /// - Note:
+    ///     [WMATA Path Details Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d69)
     ///
     /// - Parameters:
     ///     - date: Day to get details for. Omit for today
@@ -74,9 +83,12 @@ public extension Route {
 
     /// Scheduled stops for this Route
     ///
+    /// - Note:
+    ///     [WMATA Route Schedule Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6b)
+    ///
     /// - Parameters:
     ///     - date: Day to get stops for. Omit for today.
-    ///     - includingVariations: Whether to include route variations. Example: B30v1 and B30v2 for Route B30
+    ///     - includingVariations: Whether to include route variations. Optional. Example: B30v1 and B30v2 for Route B30.
     ///     - key: WMATA API Key to use with this request
     ///     - session: Optional. URL Session to make this request with
     ///     - completion: A completion handler
@@ -90,6 +102,9 @@ public extension Route {
 public extension Route {
     /// Bus positions on this Route including latlong and direction.
     ///
+    /// - Note:
+    ///     [WMATA Positions Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d68)
+    ///
     /// - Parameters:
     ///     - radiusAtCoordinates: Radius at latlong to search at
     ///     - key: WMATA API Key to use with this request
@@ -102,6 +117,9 @@ public extension Route {
 
     /// Bus incidents along this Route.
     ///
+    /// - Note:
+    ///     [WMATA Incidents Documentation](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d75)
+    ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request
     ///     - session: Optional. URL Session to make this request with
@@ -112,6 +130,9 @@ public extension Route {
     }
 
     /// Ordered latlong points along this Route for a given date.
+    ///
+    /// - Note:
+    ///     [WMATA Path Details Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d69)
     ///
     /// - Parameters:
     ///     - date: Day to get route. Omit for today.
@@ -125,9 +146,12 @@ public extension Route {
 
     /// Scheduled stops for this Route
     ///
+    /// - Note:
+    ///     [WMATA Route Schedule Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6b)
+    ///
     /// - Parameters:
     ///     - date: Day to get stops for`. Omit for today.
-    ///     - includingVariations: Whether to include route variations. Example: B30v1 and B30v2 for Route B30
+    ///     - includingVariations: Whether to include route variations. Optional. Example: B30v1 and B30v2 for Route B30
     ///     - key: WMATA API Key to use with this request
     ///     - session: Optional. URL Session to make this request with
     ///

--- a/Sources/WMATA/Bus/Stops.swift
+++ b/Sources/WMATA/Bus/Stops.swift
@@ -39,6 +39,9 @@ extension Stop: NeedsStop {}
 public extension Stop {
     /// Next bus arrival times at this Stop
     ///
+    /// - Note:
+    ///     [WMATA Next Buses Documentation](https://developer.wmata.com/docs/services/5476365e031f590f38092508/operations/5476365e031f5909e4fe331d)
+    ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request
     ///     - session: Optional. URL Session to make this request with
@@ -49,6 +52,9 @@ public extension Stop {
     }
 
     /// Set of buses scheduled to arrive at this Stop at a given date.
+    ///
+    /// - Note:
+    ///     [WMATA Stop Schedule Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6c)
     ///
     /// - Parameters:
     ///     - date: Day to get arrivals. Omit for today.
@@ -65,6 +71,9 @@ public extension Stop {
 public extension Stop {
     /// Next bus arrival times at this Stop
     ///
+    /// - Note:
+    ///     [WMATA Next Buses Documentation](https://developer.wmata.com/docs/services/5476365e031f590f38092508/operations/5476365e031f5909e4fe331d)
+    ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request
     ///     - session: Optional. URL Session to make this request with
@@ -75,6 +84,9 @@ public extension Stop {
     }
 
     /// Set of buses scheduled to arrive at this Stop at a given date.
+    ///
+    /// - Note:
+    ///     [WMATA Stop Schedule Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6c)
     ///
     /// - Parameters:
     ///     - date: Day to get scheduled arrivals. Omit for today.

--- a/Sources/WMATA/Bus/Stops.swift
+++ b/Sources/WMATA/Bus/Stops.swift
@@ -20,6 +20,12 @@ public struct Stop: Codable {
     public init(id: String) {
         self.id = id
     }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        
+        try container.encode(id)
+    }
 }
 
 extension Stop: ExpressibleByStringLiteral {

--- a/Sources/WMATA/Bus/Stops.swift
+++ b/Sources/WMATA/Bus/Stops.swift
@@ -8,9 +8,15 @@
 import Combine
 import Foundation
 
+/// A WMATA Stop ID
 public struct Stop: Codable {
+    /// A WMATA Stop ID
     public let id: String
 
+    /// Create a Stop ID
+    ///
+    /// - Parameters:
+    ///     - id: A Stop ID
     public init(id: String) {
         self.id = id
     }
@@ -26,19 +32,25 @@ extension Stop: NeedsStop {}
 
 public extension Stop {
     /// Next bus arrival times at this Stop
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - Parameter completion: completion handler which returns `BusPredictions`
-    func nextBuses(key: String, session: URLSession = URLSession.shared, completion: @escaping (Result<BusPredictions, WMATAError>) -> Void) {
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///     - completion: A completion handler
+    ///     - result: [BusPredictions](x-source-tag://BusPredictions) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func nextBuses(key: String, session: URLSession = URLSession.shared, completion: @escaping (_ result: Result<BusPredictions, WMATAError>) -> Void) {
         (self as NeedsStop).nextBuses(for: self, key: key, session: session, completion: completion)
     }
 
     /// Set of buses scheduled to arrive at this Stop at a given date.
-    /// - Parameter date: `WMATADate`. Omit for today.
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - Parameter completion: completion handler which returns `StopSchedule`
-    func schedule(at date: WMATADate? = nil, key: String, session: URLSession = URLSession.shared, completion: @escaping (Result<StopSchedule, WMATAError>) -> Void) {
+    ///
+    /// - Parameters:
+    ///     - date: Day to get arrivals. Omit for today.
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///     - completion: A completion handler
+    ///     - result: [StopSchedule](x-source-tag://StopSchedule) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func schedule(at date: WMATADate? = nil, key: String, session: URLSession = URLSession.shared, completion: @escaping (_ result: Result<StopSchedule, WMATAError>) -> Void) {
         (self as NeedsStop).schedule(for: self, at: date, key: key, session: session, completion: completion)
     }
 }
@@ -46,18 +58,24 @@ public extension Stop {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public extension Stop {
     /// Next bus arrival times at this Stop
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - returns: A Combine Publisher for `BusPredictions`
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///
+    /// - Returns: A Combine Publisher for [BusPredictions](x-source-tag://BusPredictions)
     func nextBusesPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<BusPredictions, WMATAError> {
         (self as NeedsStop).nextBusesPublisher(for: self, key: key, session: session)
     }
 
     /// Set of buses scheduled to arrive at this Stop at a given date.
-    /// - Parameter date: `WMATADate`. Omit for today.
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - returns: A Combine Publisher for `StopSchedule`
+    ///
+    /// - Parameters:
+    ///     - date: Day to get scheduled arrivals. Omit for today.
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///
+    /// - Returns: A Combine Publisher for [StopSchedule](x-source-tag://StopSchedule)
     func schedulePublisher(at date: WMATADate? = nil, key: String, session: URLSession = URLSession.shared) -> AnyPublisher<StopSchedule, WMATAError> {
         (self as NeedsStop).schedulePublisher(for: self, at: date, key: key, session: session)
     }

--- a/Sources/WMATA/Date.swift
+++ b/Sources/WMATA/Date.swift
@@ -7,11 +7,23 @@
 
 import Foundation
 
+/// Structure describing a day, month and year in a format the WMATA API will understand
 public struct WMATADate {
+    /// Year of the date
     public let year: Int
+    
+    /// Month of the date
     public let month: Int
+    
+    /// Day of the date
     public let day: Int
 
+    /// Create a WMATA Date
+    ///
+    /// - Parameters:
+    ///     - year: Year of the date
+    ///     - month: Month of the date
+    ///     - day: Day of the date
     public init(year: Int, month: Int, day: Int) {
         self.year = year
         self.month = month

--- a/Sources/WMATA/Delegate.swift
+++ b/Sources/WMATA/Delegate.swift
@@ -9,6 +9,7 @@ import Foundation
 import GTFS
 
 /// Implement this protocol in order to receive requests in the background.
+/// - Tag: WMATADelegate
 public protocol WMATADelegate {
     /// MetroRail responses
     func received(linesResponse result: Result<LinesResponse, WMATAError>)

--- a/Sources/WMATA/Delegate.swift
+++ b/Sources/WMATA/Delegate.swift
@@ -12,55 +12,84 @@ import GTFS
 /// - Tag: WMATADelegate
 public protocol WMATADelegate {
     /// MetroRail responses
+    
+    /// - Tag: DelegateLinesResponse
     func received(linesResponse result: Result<LinesResponse, WMATAError>)
 
+    /// - Tag: DelegateStationEntrances
     func received(stationEntrances result: Result<StationEntrances, WMATAError>)
 
+    /// - Tag: DelegateTrainPositions
     func received(trainPositions result: Result<TrainPositions, WMATAError>)
 
+    /// - Tag: DelegateStandardRoutes
     func received(standardRoutes result: Result<StandardRoutes, WMATAError>)
 
+    /// - Tag: DelegateTrackCircuits
     func received(trackCircuits result: Result<TrackCircuits, WMATAError>)
 
+    /// - Tag: DelegateElevatorAndEscalatorIncidents
     func received(elevatorAndEscalatorIncidents result: Result<ElevatorAndEscalatorIncidents, WMATAError>)
 
+    /// - Tag: DelegateRailIncidents
     func received(railIncidents result: Result<RailIncidents, WMATAError>)
 
+    /// - Tag: DelegateRailPredictions
     func received(railPredictions result: Result<RailPredictions, WMATAError>)
 
+    /// - Tag: DelegateStationInformation
     func received(stationInformation result: Result<StationInformation, WMATAError>)
 
+    /// - Tag: DelegateStationsParking
     func received(stationsParking result: Result<StationsParking, WMATAError>)
 
+    /// - Tag: DelegatePathBetweenStations
     func received(pathBetweenStations result: Result<PathBetweenStations, WMATAError>)
 
+    /// - Tag: DelegateStationTimings
     func received(stationTimings result: Result<StationTimings, WMATAError>)
 
+    /// - Tag: DelegateStationToStationInfos
     func received(stationToStationInfos result: Result<StationToStationInfos, WMATAError>)
 
+    /// - Tag: DelegateStations
     func received(stations result: Result<Stations, WMATAError>)
 
     /// MetroBus responses
+    
+    /// - Tag: DelegateRoutesResponse
     func received(routesResponse result: Result<RoutesResponse, WMATAError>)
 
+    /// - Tag: DelegateStopsSearchResponse
     func received(stopSearchResponse result: Result<StopsSearchResponse, WMATAError>)
 
+    /// - Tag: DelegateBusIncidents
     func received(busIncidents result: Result<BusIncidents, WMATAError>)
 
+    /// - Tag: DelegateBusPositions
     func received(busPositions result: Result<BusPositions, WMATAError>)
 
+    /// - Tag: DelegatePathDetails
     func received(pathDetails result: Result<PathDetails, WMATAError>)
 
+    /// - Tag: DelegateRouteSchedule
     func received(routeSchedule result: Result<RouteSchedule, WMATAError>)
 
+    /// - Tag: DelegateBusPredictions
     func received(busPredictions result: Result<BusPredictions, WMATAError>)
 
+    /// - Tag: DelegateStopSchedule
     func received(stopSchedule result: Result<StopSchedule, WMATAError>)
+    
+    /// GTFS-RT responses
 
+    /// - Tag: DelegateAlerts
     func received(alerts result: Result<TransitRealtime_FeedMessage, WMATAError>)
 
+    /// - Tag: DelegateTripUpdates
     func received(tripUpdates result: Result<TransitRealtime_FeedMessage, WMATAError>)
 
+    /// - Tag: DelegateVehiclePositions
     func received(vehiclePositions result: Result<TransitRealtime_FeedMessage, WMATAError>)
 }
 

--- a/Sources/WMATA/Deserialize.swift
+++ b/Sources/WMATA/Deserialize.swift
@@ -14,8 +14,10 @@ protocol Deserializer {}
 extension Deserializer {
     /// Default implemention for deserialize.
     ///
-    /// - parameter data: Data to deserialize
-    /// - returns: Result container the deserialized data, or an error
+    /// - Parameters:
+    ///     - data: Data to deserialize
+    ///
+    /// - Returns: Result container the deserialized data, or an error
     func deserialize<T: Codable>(_ data: Data) -> Result<T, WMATAError> {
         do {
             return .success(try JSONDecoder().decode(T.self, from: data))

--- a/Sources/WMATA/Errors.swift
+++ b/Sources/WMATA/Errors.swift
@@ -5,6 +5,8 @@
 //  Created by Emma K Alexandra on 6/23/19.
 //
 
+/// - Tag: WMATAError
+/// Error type for all errors that occur with the WMATA package.
 public struct WMATAError: Codable, Error {
     public let statusCode: Int
     public let message: String

--- a/Sources/WMATA/Errors.swift
+++ b/Sources/WMATA/Errors.swift
@@ -5,8 +5,8 @@
 //  Created by Emma K Alexandra on 6/23/19.
 //
 
-/// - Tag: WMATAError
 /// Error type for all errors that occur with the WMATA package.
+/// - Tag: WMATAError
 public struct WMATAError: Codable, Error {
     public let statusCode: Int
     public let message: String

--- a/Sources/WMATA/Location.swift
+++ b/Sources/WMATA/Location.swift
@@ -7,15 +7,30 @@
 
 import Foundation
 
+/// For defining a location and radius from that location
 public struct RadiusAtCoordinates {
+    /// Radius from location in meters
     public let radius: UInt
+    
+    /// Location in latlong
     public let coordinates: Coordinates
 
+    /// Create a new location and radius
+    ///
+    /// - Parameters:
+    ///     - radius: Radius in meters from the given coordinates
+    ///     - coordinates: Coordinates of location
     public init(radius: UInt, coordinates: Coordinates) {
         self.radius = radius
         self.coordinates = coordinates
     }
 
+    /// Create a new location and radius
+    ///
+    /// - Parameters:
+    ///     - radius: Radius in meters from the given coordinates
+    ///     - latitude: Latitude of location
+    ///     - longitude: Longitude of location
     public init(radius: UInt, latitude: Double, longitude: Double) {
         self.init(radius: radius, coordinates: Coordinates(latitude: latitude, longitude: longitude))
     }
@@ -25,10 +40,19 @@ public struct RadiusAtCoordinates {
     }
 }
 
+/// Location in latlong
 public struct Coordinates {
+    /// Latitude in degrees, positive
     public let latitude: Double
+    
+    /// Longitude in degrees, negative
     public let longitude: Double
 
+    /// Create a new location
+    ///
+    /// - Parameters:
+    ///     - latitude: Latitude of location in degrees, positive
+    ///     - longitude: Longitude of location in degrees, negative
     public init(latitude: Double, longitude: Double) {
         self.latitude = latitude
         self.longitude = longitude

--- a/Sources/WMATA/MetroBus.swift
+++ b/Sources/WMATA/MetroBus.swift
@@ -33,8 +33,8 @@ public struct MetroBus: Fetcher {
     ///
     /// - Parameters:
     ///     - key: Your WMATA API key
-    ///     - delegate: The delegate to use for all delegate calls
-    ///     - sharedContainerIdentifier: Identifier for use with app extensions
+    ///     - delegate: The delegate to use for all delegate calls. Optional.
+    ///     - sharedContainerIdentifier: Identifier for use with app extensions. Optional.
     public init(key: String, delegate: WMATADelegate? = nil, sharedContainerIdentifier: String? = nil) {
         self.key = key
 
@@ -55,6 +55,9 @@ public struct MetroBus: Fetcher {
 public extension MetroBus {
     /// All bus routes and variants
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// - Note:
+    ///     [WMATA Routes Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6a)
     func routes() {
         request(
             request: URLRequest(url: BusURL.routes.rawValue, key: key),
@@ -63,6 +66,9 @@ public extension MetroBus {
     }
 
     /// All bus routes and variants
+    ///
+    /// - Note:
+    ///     [WMATA Routes Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6a)
     ///
     /// - Parameters:
     ///     - completion: Completion handler which returns `RoutesResponse`
@@ -78,8 +84,11 @@ public extension MetroBus {
     /// Stops nearby the given latitude, longitude and radius. Omit latitude, longitude and radius to receive all stops.
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Search Stop Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6d)
+    ///
     /// - Parameters:
-    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at. Optional.
     func searchStops(at radiusAtCoordinates: RadiusAtCoordinates? = nil) {
         var queryItems = [(String, String)]()
 
@@ -95,8 +104,11 @@ public extension MetroBus {
 
     /// Stops nearby the given latitude, longitude and radius. Omit latitude, longitude and radius to receive all stops.
     ///
+    /// - Note:
+    ///     [WMATA Search Stop Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6d)
+    ///
     /// - Parameters:
-    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at. Optional.
     ///     - completion: A completion handler
     ///     - result: [StopsSearchResponse](x-source-tag://StopsSearchResponse) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
     func searchStops(at radiusAtCoordinates: RadiusAtCoordinates? = nil, completion: @escaping (_ result: Result<StopsSearchResponse, WMATAError>) -> Void) {
@@ -118,6 +130,9 @@ public extension MetroBus {
 public extension MetroBus {
     /// All bus routes and variants
     ///
+    /// - Note:
+    ///     [WMATA Routes Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6a)
+    ///
     /// - Returns: A Combine Publisher for [RoutesResponse](x-source-tag://RoutesResponse)
     func routesPublisher() -> AnyPublisher<RoutesResponse, WMATAError> {
         publisher(
@@ -128,8 +143,11 @@ public extension MetroBus {
 
     /// Stops nearby the given latitude, longitude and radius. Omit latitude, longitude and radius to receive all stops.
     ///
+    /// - Note:
+    ///     [WMATA Search Stops Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6d)
+    ///
     /// - Parameters:
-    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at. Optional.
     ///
     /// - Returns: A Combine Publisher for [StopsSearchResponse](x-source-tag://StopsSearchResponse)
     func searchStopsPublisher(at radiusAtCoordinates: RadiusAtCoordinates? = nil) -> AnyPublisher<StopsSearchResponse, WMATAError> {
@@ -152,18 +170,24 @@ public extension MetroBus {
     /// Bus positions including latlong and direction. Omit routeId, latitude, longitude and radius to receive all bus positions.
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Positions Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d68)
+    ///
     /// - Parameters:
-    ///     - route: Get bus positions along this route
-    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
+    ///     - route: Get bus positions along this route. Optional.
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at. Optional.
     func positions(on route: Route? = nil, at radiusAtCoordinates: RadiusAtCoordinates? = nil) {
         (self as NeedsRoute).positions(on: route, at: radiusAtCoordinates, key: key, session: session)
     }
 
     /// Bus positions including latlong and direction. Omit routeId, latitude, longitude and radius to receive all bus positions.
     ///
+    /// - Note:
+    ///     [WMATA Positions Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d68)
+    ///
     /// - Parameters:
-    ///     - route: Get bus positions along this route
-    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
+    ///     - route: Get bus positions along this route. Optional.
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at. Optional.
     ///     - completion: Completion handler which returns `BusPositions`
     ///     - result: [BusPositions](x-source-tag://BusPositions) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
     func positions(on route: Route? = nil, at radiusAtCoordinates: RadiusAtCoordinates? = nil, completion: @escaping (_ result: Result<BusPositions, WMATAError>) -> Void) {
@@ -173,6 +197,9 @@ public extension MetroBus {
     /// Bus incidents along a given route.
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Incidents Documentation](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d75)
+    ///
     /// - Parameters:
     ///     - route: Route to search for incidents along. Omit route to receive all incidents.
     func incidents(on route: Route? = nil) {
@@ -180,6 +207,9 @@ public extension MetroBus {
     }
 
     /// Bus incidents along a given route.
+    ///
+    /// - Note:
+    ///     [WMATA Incidents Documentation](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d75)
     ///
     /// - Parameters:
     ///     - route: Route to search for incidents along. Omit route to receive all incidents.
@@ -192,6 +222,9 @@ public extension MetroBus {
     /// Ordered latlong points along this Route for a given date. Omit date to get path information for today.
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Path Details Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d69)
+    ///
     /// - Parameters:
     ///     - route: Route to get path details for
     ///     - date: Day  for which to receive path information. Omit for today.
@@ -201,9 +234,12 @@ public extension MetroBus {
 
     /// Ordered latlong points along this Route for a given date. Omit date to get path information for today.
     ///
+    /// - Note:
+    ///     [WMATA Path Details Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d69)
+    ///
     /// - Parameters:
-    ///     - route: `Route` to get path details for
-    ///     - date: `WMATADate`  for which to receive path information. Omit for today.
+    ///     - route: Route to get path details for
+    ///     - date: Day  for which to receive path information. Omit for today.
     ///     - completion: A completion handler
     ///     - result: [PathDetails](x-source-tag://PathDetails) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
     func pathDetails(for route: Route, on date: WMATADate? = nil, completion: @escaping (_ result: Result<PathDetails, WMATAError>) -> Void) {
@@ -213,15 +249,21 @@ public extension MetroBus {
     /// Scheduled stops for this Route
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Route Schedule Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6b)
+    ///
     /// - Parameters:
     ///     - route: Route to get stops for
-    ///     - date: Day for which to receive scheduled stops. nil for today.
+    ///     - date: Day for which to receive scheduled stops. Omit for today.
     ///     - includingVariations: Whether to include route variations. Example: B30v1 and B30v2 for Route B30
     func routeSchedule(for route: Route, on date: WMATADate? = nil, includingVariations: Bool? = false) {
         (self as NeedsRoute).schedule(for: route, on: date, includingVariations: includingVariations, key: key, session: session)
     }
 
     /// Scheduled stops for this Route
+    ///
+    /// - Note:
+    ///     [WMATA Route Schedule Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6b)
     ///
     /// - Parameters:
     ///     - route: Route to get stops for
@@ -238,9 +280,12 @@ public extension MetroBus {
 public extension MetroBus {
     /// Bus positions including latlong and direction. Omit routeId, latitude, longitude and radius to receive all bus positions.
     ///
+    /// - Note:
+    ///     [WMATA Positions Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d68)
+    ///
     /// - Parameters:
-    ///     - route: Get bus positions along this route
-    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
+    ///     - route: Get bus positions along this route. Optional.
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at. Optional.
     ///
     /// - Returns: A Combine Publisher for [BusPositions](x-source-tag://BusPositions)
     func positionsPublisher(on route: Route? = nil, at radiusAtCoordinates: RadiusAtCoordinates? = nil) -> AnyPublisher<BusPositions, WMATAError> {
@@ -248,6 +293,9 @@ public extension MetroBus {
     }
 
     /// Bus incidents along a given route.
+    ///
+    /// - Note:
+    ///     [WMATA Incidents Documentation](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d75)
     ///
     /// - Parameters:
     ///     - route: Route to search for incidents along. Omit route to receive all incidents.
@@ -258,6 +306,9 @@ public extension MetroBus {
     }
 
     /// Ordered latlong points along this Route for a given date. Omit date to get path information for today.
+    ///
+    /// - Note:
+    ///     [WMATA Path Details Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d69)
     ///
     /// - Parameters:
     ///     - route: Route to get path details for
@@ -270,9 +321,12 @@ public extension MetroBus {
 
     /// Scheduled stops for this Route
     ///
+    /// - Note:
+    ///     [WMATA Route Schedule Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6b)
+    ///
     /// - Parameters:
     ///     - route: Route to get stops for
-    ///     - date: Day for which to receive scheduled stops. nil for today.
+    ///     - date: Day for which to receive scheduled stops. Omit for today.
     ///     - includingVariations: Whether to include route variations. Example: B30v1 and B30v2 for Route B30
     ///
     /// - Returns: A Combine Publisher for [RouteSchedule](x-source-tag://RouteSchedule)
@@ -287,6 +341,9 @@ public extension MetroBus {
     /// Next bus arrival times at this Stop
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Next Buses Documentation](https://developer.wmata.com/docs/services/5476365e031f590f38092508/operations/5476365e031f5909e4fe331d)
+    ///
     /// - Parameters:
     ///     - stop: Stop to get next arrival times for
     func nextBuses(for stop: Stop) {
@@ -294,6 +351,9 @@ public extension MetroBus {
     }
 
     /// Next bus arrival times at this Stop
+    ///
+    /// - Note:
+    ///     [WMATA Next Buses Documentation](https://developer.wmata.com/docs/services/5476365e031f590f38092508/operations/5476365e031f5909e4fe331d)
     ///
     /// - Parameters:
     ///     - stop: Stop to get next arrival times for
@@ -306,6 +366,9 @@ public extension MetroBus {
     /// Set of buses scheduled to arrive at this Stop at a given date.
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Stop Schedule Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6c)
+    ///
     /// - Parameters:
     ///     - stop: Stop to get schedule for
     ///     - date: Day for which to receive schedule for. Omit for today.
@@ -314,6 +377,9 @@ public extension MetroBus {
     }
 
     /// Set of buses scheduled to arrive at this Stop at a given date.
+    ///
+    /// - Note:
+    ///     [WMATA Stop Schedule Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6c)
     ///
     /// - Parameters:
     ///     - stop: Stop to get schedule for
@@ -329,6 +395,9 @@ public extension MetroBus {
 public extension MetroBus {
     /// Next bus arrival times at this Stop
     ///
+    /// - Note:
+    ///     [WMATA Next Buses Documentation](https://developer.wmata.com/docs/services/5476365e031f590f38092508/operations/5476365e031f5909e4fe331d)
+    ///
     /// - Parameters:
     ///     - stop: Stop to get next arrival times for
     ///
@@ -338,6 +407,9 @@ public extension MetroBus {
     }
 
     /// Set of buses scheduled to arrive at this Stop at a given date.
+    ///
+    /// - Note:
+    ///     [WMATA Stop Schedule Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6c)
     ///
     /// - Parameters:
     ///     - stop: Stop to get schedule for
@@ -354,7 +426,9 @@ extension MetroBus: GTFSRTFetcher {}
 /// GTFS-RT
 public extension MetroBus {
     /// GTFS RT 2.0 service alerts feed for WMATA bus.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/service-alerts
+    ///
+    /// - Note:
+    ///     [Google Alerts Documentation](https://developers.google.com/transit/gtfs-realtime/guides/service-alerts)
     ///
     /// - Parameters:
     ///     - completion: A completion handler
@@ -368,8 +442,10 @@ public extension MetroBus {
     }
 
     /// GTFS RT 2.0 service alerts feed for WMATA bus.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/service-alerts
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// - Note:
+    ///     [Google Alerts Documentation](https://developers.google.com/transit/gtfs-realtime/guides/service-alerts)
     func alerts() {
         request(
             request: URLRequest(
@@ -381,7 +457,9 @@ public extension MetroBus {
     }
 
     /// GTFS RT 2.0 trip updates feed for WMATA bus.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/trip-updates
+    ///
+    /// - Note:
+    ///     [Google Trip Updates Documentation](https://developers.google.com/transit/gtfs-realtime/guides/trip-updates)
     ///
     /// - Parameters:
     ///     - completion: A completion handler
@@ -398,8 +476,10 @@ public extension MetroBus {
     }
 
     /// GTFS RT 2.0 trip updates feed for WMATA bus.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/trip-updates
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// - Note:
+    ///     [Google Trip Updates Documentation](https://developers.google.com/transit/gtfs-realtime/guides/trip-updates)
     func tripUpdates() {
         request(
             request: URLRequest(
@@ -411,7 +491,9 @@ public extension MetroBus {
     }
 
     /// GTFS RT 2.0 vehicle positions feed for WMATA bus.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions
+    ///
+    /// - Note:
+    ///     [Google Vehicle Positions Documentation](https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions)
     ///
     /// - Parameters:
     ///     - completion: A completion handler
@@ -424,9 +506,11 @@ public extension MetroBus {
         )
     }
 
-    /// GTFS RT 2.0 vehicle positions feed for WMATA bus.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions
+    /// GTFS RT 2.0 vehicle positions feed for WMATA
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// - Note:
+    ///     [Google Vehicle Positions Documentation](https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions)
     func vehiclePositions() {
         request(
             request: URLRequest(
@@ -441,7 +525,9 @@ public extension MetroBus {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public extension MetroBus {
     /// GTFS RT 2.0 service alerts feed for WMATA bus.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/service-alerts
+    ///
+    /// - Note:
+    ///     [Google Alerts Documentation](https://developers.google.com/transit/gtfs-realtime/guides/service-alerts)
     ///
     /// - Returns: A Combine Publisher for `TransitRealtime_FeedMessage`
     func alertsPublisher() -> AnyPublisher<TransitRealtime_FeedMessage, WMATAError> {
@@ -454,8 +540,10 @@ public extension MetroBus {
         )
     }
 
-    /// GTFS RT 2.0 trip updates feed for WMATA bus.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/trip-updates
+    /// GTFS RT 2.0 trip updates feed for WMATA
+    ///
+    /// - Note:
+    ///     [Google Trip Updates Documentation](https://developers.google.com/transit/gtfs-realtime/guides/trip-updates)
     ///
     /// - Returns: A Combine Publisher for `TransitRealtime_FeedMessage`
     func tripUpdatesPublisher() -> AnyPublisher<TransitRealtime_FeedMessage, WMATAError> {
@@ -469,7 +557,9 @@ public extension MetroBus {
     }
 
     /// GTFS RT 2.0 vehicle positions feed for WMATA bus.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions
+    ///
+    /// - Note:
+    ///     [Google Vehicle Positions Documentation](https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions)
     ///
     /// - Returns: A Combine Publisher for`TransitRealtime_FeedMessage`
     func vehiclePositionsPublisher() -> AnyPublisher<TransitRealtime_FeedMessage, WMATAError> {

--- a/Sources/WMATA/MetroBus.swift
+++ b/Sources/WMATA/MetroBus.swift
@@ -9,9 +9,12 @@ import Combine
 import Foundation
 import GTFS
 
-/// MetroBus related methods
+/// For accessing MetroBus related APIs
 public struct MetroBus: Fetcher {
+    /// WMATA API key
     public let key: String
+    
+    /// Delegate for use with delegate calls
     public var delegate: WMATADelegate? {
         didSet {
             if let delegate = self.delegate {
@@ -20,10 +23,18 @@ public struct MetroBus: Fetcher {
         }
     }
 
+    /// The shared container identifier for use with app extensions. See [URLSessionConfiguration](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1409450-sharedcontaineridentifier)
     public private(set) var sharedContainerIdentifier: String?
 
+    /// URL session to use for all calls
     private var session: URLSession
 
+    /// Create a new MetroBus instance
+    ///
+    /// - Parameters:
+    ///     - key: Your WMATA API key
+    ///     - delegate: The delegate to use for all delegate calls
+    ///     - sharedContainerIdentifier: Identifier for use with app extensions
     public init(key: String, delegate: WMATADelegate? = nil, sharedContainerIdentifier: String? = nil) {
         self.key = key
 
@@ -53,8 +64,10 @@ public extension MetroBus {
 
     /// All bus routes and variants
     ///
-    /// - Parameter completion: Completion handler which returns `RoutesResponse`
-    func routes(completion: @escaping (Result<RoutesResponse, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - completion: Completion handler which returns `RoutesResponse`
+    ///     - result: [RoutesResponse](x-source-tag://RoutesResponse) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func routes(completion: @escaping (_ result: Result<RoutesResponse, WMATAError>) -> Void) {
         fetch(
             request: URLRequest(url: BusURL.routes.rawValue, key: key),
             session: session,
@@ -65,7 +78,8 @@ public extension MetroBus {
     /// Stops nearby the given latitude, longitude and radius. Omit latitude, longitude and radius to receive all stops.
     /// For use with a `WMATADelegate`
     ///
-    /// - parameter radiusAtCoordinates: Radius at latitude and longitude to search at
+    /// - Parameters:
+    /// - radiusAtCoordinates: Radius at latitude and longitude to search at
     func searchStops(at radiusAtCoordinates: RadiusAtCoordinates?) {
         var queryItems = [(String, String)]()
 
@@ -81,9 +95,11 @@ public extension MetroBus {
 
     /// Stops nearby the given latitude, longitude and radius. Omit latitude, longitude and radius to receive all stops.
     ///
-    /// - parameter radiusAtCoordinates: Radius at latitude and longitude to search at
-    /// - parameter completion: Completion handler which returns `StopsSearchResponse`
-    func searchStops(at radiusAtCoordinates: RadiusAtCoordinates?, completion: @escaping (Result<StopsSearchResponse, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
+    ///     - completion: A completion handler
+    ///     - result: [StopsSearchResponse](x-source-tag://StopsSearchResponse) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func searchStops(at radiusAtCoordinates: RadiusAtCoordinates?, completion: @escaping (_ result: Result<StopsSearchResponse, WMATAError>) -> Void) {
         var queryItems = [(String, String)]()
 
         if let radiusAtCoordinates = radiusAtCoordinates {
@@ -102,7 +118,7 @@ public extension MetroBus {
 public extension MetroBus {
     /// All bus routes and variants
     ///
-    /// - returns: A Combine Publisher for `RoutesResponse`
+    /// - Returns: A Combine Publisher for [RoutesResponse](x-source-tag://RoutesResponse)
     func routesPublisher() -> AnyPublisher<RoutesResponse, WMATAError> {
         publisher(
             request: URLRequest(url: BusURL.routes.rawValue, key: key),
@@ -112,8 +128,10 @@ public extension MetroBus {
 
     /// Stops nearby the given latitude, longitude and radius. Omit latitude, longitude and radius to receive all stops.
     ///
-    /// - parameter radiusAtCoordinates: Radius at latitude and longitude to search at
-    /// - parameter completion: Completion handler which returns `StopsSearchResponse`
+    /// - Parameters:
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
+    ///
+    /// - Returns: A Combine Publisher for [StopsSearchResponse](x-source-tag://StopsSearchResponse)
     func searchStopsPublisher(at radiusAtCoordinates: RadiusAtCoordinates?) -> AnyPublisher<StopsSearchResponse, WMATAError> {
         var queryItems = [(String, String)]()
 
@@ -134,72 +152,84 @@ public extension MetroBus {
     /// Bus positions including latlong and direction. Omit routeId, latitude, longitude and radius to receive all bus positions.
     /// For use with a `WMATADelegate`
     ///
-    /// - parameter route: Get bus positions along this route
-    /// - parameter radiusAtCoordinates: Radius at latitude and longitude to search at
+    /// - Parameters:
+    ///     - route: Get bus positions along this route
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
     func positions(on route: Route?, at radiusAtCoordinates: RadiusAtCoordinates?) {
         (self as NeedsRoute).positions(on: route, at: radiusAtCoordinates, key: key, session: session)
     }
 
     /// Bus positions including latlong and direction. Omit routeId, latitude, longitude and radius to receive all bus positions.
     ///
-    /// - parameter route: Get bus positions along this route
-    /// - parameter radiusAtCoordinates: Radius at latitude and longitude to search at
-    /// - parameter completion: Completion handler which returns `BusPositions`
-    func positions(on route: Route?, at radiusAtCoordinates: RadiusAtCoordinates?, completion: @escaping (Result<BusPositions, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - route: Get bus positions along this route
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
+    ///     - completion: Completion handler which returns `BusPositions`
+    ///     - result: [BusPositions](x-source-tag://BusPositions) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func positions(on route: Route?, at radiusAtCoordinates: RadiusAtCoordinates?, completion: @escaping (_ result: Result<BusPositions, WMATAError>) -> Void) {
         (self as NeedsRoute).positions(on: route, at: radiusAtCoordinates, key: key, session: session, completion: completion)
     }
 
     /// Bus incidents along a given route.
     /// For use with a `WMATADelegate`
     ///
-    /// - parameter route: Route to search for incidents along. Omit route to receive all incidents.
+    /// - Parameters:
+    ///     - route: Route to search for incidents along. Omit route to receive all incidents.
     func incidents(on route: Route?) {
         (self as NeedsRoute).incidents(on: route, key: key, session: session)
     }
 
     /// Bus incidents along a given route.
     ///
-    /// - parameter route: Route to search for incidents along. Omit route to receive all incidents.
-    /// - parameter completion: Completion handler which returns `BusIncidents`
-    func incidents(on route: Route?, completion: @escaping (Result<BusIncidents, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - route: Route to search for incidents along. Omit route to receive all incidents.
+    ///     - completion: A completion handler
+    ///     - result: [BusIncidents](x-source-tag://BusIncidents) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func incidents(on route: Route?, completion: @escaping (_ result: Result<BusIncidents, WMATAError>) -> Void) {
         (self as NeedsRoute).incidents(on: route, key: key, session: session, completion: completion)
     }
 
     /// Ordered latlong points along this Route for a given date. Omit date to get path information for today.
     /// For use with a `WMATADelegate`
     ///
-    /// - parameter route: `Route` to get path details for
-    /// - parameter date: `WMATADate`  for which to receive path information. Omit for today.
+    /// - Parameters:
+    ///     - route: Route to get path details for
+    ///     - date: Day  for which to receive path information. Omit for today.
     func pathDetails(for route: Route, on date: WMATADate? = nil) {
         (self as NeedsRoute).pathDetails(for: route, on: date, key: key, session: session)
     }
 
     /// Ordered latlong points along this Route for a given date. Omit date to get path information for today.
     ///
-    /// - parameter route: `Route` to get path details for
-    /// - parameter date: `WMATADate`  for which to receive path information. Omit for today.
-    /// - parameter completion: Completion handler which returns `PathDetails`
-    func pathDetails(for route: Route, on date: WMATADate? = nil, completion: @escaping (Result<PathDetails, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - route: `Route` to get path details for
+    ///     - date: `WMATADate`  for which to receive path information. Omit for today.
+    ///     - completion: A completion handler
+    ///     - result: [PathDetails](x-source-tag://PathDetails) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func pathDetails(for route: Route, on date: WMATADate? = nil, completion: @escaping (_ result: Result<PathDetails, WMATAError>) -> Void) {
         (self as NeedsRoute).pathDetails(for: route, on: date, key: key, session: session, completion: completion)
     }
 
     /// Scheduled stops for this Route
     /// For use with a `WMATADelegate`
     ///
-    /// - parameter route: `Route` to get stops for
-    /// - parameter date: `WMATADate` for which to receive scheduled stops. nil for today.
-    /// - parameter includingVariations: Whether to include route variations. Example: B30v1 and B30v2 for Route B30
+    /// - Parameters:
+    ///     - route: Route to get stops for
+    ///     - date: Day for which to receive scheduled stops. nil for today.
+    ///     - includingVariations: Whether to include route variations. Example: B30v1 and B30v2 for Route B30
     func routeSchedule(for route: Route, on date: WMATADate? = nil, includingVariations: Bool? = false) {
         (self as NeedsRoute).schedule(for: route, on: date, includingVariations: includingVariations, key: key, session: session)
     }
 
     /// Scheduled stops for this Route
     ///
-    /// - parameter route: `Route` to get stops for
-    /// - parameter date: `WMATADate` for which to receive scheduled stops. nil for today.
-    /// - parameter includingVariations: Whether to include route variations. Example: B30v1 and B30v2 for Route B30
-    /// - parameter completion: Completion handler which returns `RoutesResponse`
-    func routeSchedule(for route: Route, on date: WMATADate? = nil, includingVariations: Bool? = false, completion: @escaping (Result<RouteSchedule, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - route: Route to get stops for
+    ///     - date: Day for which to receive scheduled stops. Omit for today.
+    ///     - includingVariations: Whether to include route variations. Example: B30v1 and B30v2 for Route B30
+    ///     - completion: A completion handler
+    ///     - result: [RouteSchedule](x-source-tag://RouteSchedule) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func routeSchedule(for route: Route, on date: WMATADate? = nil, includingVariations: Bool? = false, completion: @escaping (_ result: Result<RouteSchedule, WMATAError>) -> Void) {
         (self as NeedsRoute).schedule(for: route, on: date, includingVariations: includingVariations, key: key, session: session, completion: completion)
     }
 }
@@ -208,36 +238,44 @@ public extension MetroBus {
 public extension MetroBus {
     /// Bus positions including latlong and direction. Omit routeId, latitude, longitude and radius to receive all bus positions.
     ///
-    /// - parameter route: Get bus positions along this route
-    /// - parameter radiusAtCoordinates: Radius at latitude and longitude to search at
-    /// - returns: A Combine Publisher for`BusPositions`
+    /// - Parameters:
+    ///     - route: Get bus positions along this route
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
+    ///
+    /// - Returns: A Combine Publisher for [BusPositions](x-source-tag://BusPositions)
     func positionsPublisher(on route: Route?, at radiusAtCoordinates: RadiusAtCoordinates?) -> AnyPublisher<BusPositions, WMATAError> {
         (self as NeedsRoute).positionsPublisher(on: route, at: radiusAtCoordinates, key: key, session: session)
     }
 
     /// Bus incidents along a given route.
     ///
-    /// - parameter route: Route to search for incidents along. Omit route to receive all incidents.
-    /// - returns: A Combine Publisher for`BusIncidents`
+    /// - Parameters:
+    ///     - route: Route to search for incidents along. Omit route to receive all incidents.
+    ///
+    /// - Returns: A Combine Publisher for [BusIncidents](x-source-tag://BusIncidents)
     func incidentsPublisher(on route: Route?) -> AnyPublisher<BusIncidents, WMATAError> {
         (self as NeedsRoute).incidentsPublisher(on: route, key: key, session: session)
     }
 
     /// Ordered latlong points along this Route for a given date. Omit date to get path information for today.
     ///
-    /// - parameter route: `Route` to get path details for
-    /// - parameter date: `WMATADate`  for which to receive path information. Omit for today.
-    /// - returns: A Combine Publisher for`PathDetails`
+    /// - Parameters:
+    ///     - route: Route to get path details for
+    ///     - date: Day  for which to receive path information. Omit for today.
+    ///
+    /// - Returns: A Combine Publisher for [PathDetails](x-source-tag://PathDetails)
     func pathDetailsPublisher(for route: Route, on date: WMATADate? = nil) -> AnyPublisher<PathDetails, WMATAError> {
         (self as NeedsRoute).pathDetailsPublisher(for: route, on: date, key: key, session: session)
     }
 
     /// Scheduled stops for this Route
     ///
-    /// - parameter route: `Route` to get stops for
-    /// - parameter date: `WMATADate` for which to receive scheduled stops. nil for today.
-    /// - parameter includingVariations: Whether to include route variations. Example: B30v1 and B30v2 for Route B30
-    /// - returns: A Combine Publisher for`RouteSchedule`
+    /// - Parameters:
+    ///     - route: Route to get stops for
+    ///     - date: Day for which to receive scheduled stops. nil for today.
+    ///     - includingVariations: Whether to include route variations. Example: B30v1 and B30v2 for Route B30
+    ///
+    /// - Returns: A Combine Publisher for [RouteSchedule](x-source-tag://RouteSchedule)
     func routeSchedulePublisher(for route: Route, on date: WMATADate? = nil, includingVariations: Bool? = false) -> AnyPublisher<RouteSchedule, WMATAError> {
         (self as NeedsRoute).schedulePublisher(for: route, on: date, includingVariations: includingVariations, key: key, session: session)
     }
@@ -249,34 +287,40 @@ public extension MetroBus {
     /// Next bus arrival times at this Stop
     /// For use with a `WMATADelegate`
     ///
-    /// - parameter stop: Stop to get next arrival times for
+    /// - Parameters:
+    ///     - stop: Stop to get next arrival times for
     func nextBuses(for stop: Stop) {
         (self as NeedsStop).nextBuses(for: stop, key: key, session: session)
     }
 
     /// Next bus arrival times at this Stop
     ///
-    /// - parameter stop: Stop to get next arrival times for
-    /// - parameter completion: Completion handler which returns `BusPredictions`
-    func nextBuses(for stop: Stop, completion: @escaping (Result<BusPredictions, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - stop: Stop to get next arrival times for
+    ///     - completion: A completion handler
+    ///     - result: [BusPredictions](x-source-tag://BusPredictions) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func nextBuses(for stop: Stop, completion: @escaping (_ result: Result<BusPredictions, WMATAError>) -> Void) {
         (self as NeedsStop).nextBuses(for: stop, key: key, session: session, completion: completion)
     }
 
     /// Set of buses scheduled to arrive at this Stop at a given date.
     /// For use with a `WMATADelegate`
     ///
-    /// - parameter stop: Stop to get schedule for
-    /// - parameter date: `WMATADate` for which to receive schedule for. Omit for today.
+    /// - Parameters:
+    ///     - stop: Stop to get schedule for
+    ///     - date: Day for which to receive schedule for. Omit for today.
     func stopSchedule(for stop: Stop, at date: WMATADate? = nil) {
         (self as NeedsStop).schedule(for: stop, at: date, key: key, session: session)
     }
 
     /// Set of buses scheduled to arrive at this Stop at a given date.
     ///
-    /// - parameter stop: Stop to get schedule for
-    /// - parameter date: `WMATADate` for which to receive schedule for. Omit for today.
-    /// - parameter completion: Completion handler which returns `StopSchedule`
-    func stopSchedule(for stop: Stop, at date: WMATADate? = nil, completion: @escaping (Result<StopSchedule, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - stop: Stop to get schedule for
+    ///     - date: Day for which to receive schedule for. Omit for today.
+    ///     - completion: A completion handler.
+    ///     - result: [StopSchedule](x-source-tag://StopSchedule) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func stopSchedule(for stop: Stop, at date: WMATADate? = nil, completion: @escaping (_ result: Result<StopSchedule, WMATAError>) -> Void) {
         (self as NeedsStop).schedule(for: stop, at: date, key: key, session: session, completion: completion)
     }
 }
@@ -285,17 +329,21 @@ public extension MetroBus {
 public extension MetroBus {
     /// Next bus arrival times at this Stop
     ///
-    /// - parameter stop: Stop to get next arrival times for
-    /// - returns: A Combine Publisher for `BusPredictions`
+    /// - Parameters:
+    ///     - stop: Stop to get next arrival times for
+    ///
+    /// - Returns: A Combine Publisher for [BusPredictions](x-source-tag://BusPrediction)
     func nextBusesPublisher(for stop: Stop) -> AnyPublisher<BusPredictions, WMATAError> {
         (self as NeedsStop).nextBusesPublisher(for: stop, key: key, session: session)
     }
 
     /// Set of buses scheduled to arrive at this Stop at a given date.
     ///
-    /// - parameter stop: Stop to get schedule for
-    /// - parameter date: `WMATADate` for which to receive schedule for. Omit for today.
-    /// - returns: A Combine Publisher for `StopSchedule`
+    /// - Parameters:
+    ///     - stop: Stop to get schedule for
+    ///     - date: Day for which to receive schedule for. Omit for today.
+    ///
+    /// - Returns: A Combine Publisher for [StopSchedule](x-source-tag://StopSchedule)
     func stopSchedulePublisher(for stop: Stop, at date: WMATADate? = nil) -> AnyPublisher<StopSchedule, WMATAError> {
         (self as NeedsStop).schedulePublisher(for: stop, at: date, key: key, session: session)
     }
@@ -308,8 +356,10 @@ public extension MetroBus {
     /// GTFS RT 2.0 service alerts feed for WMATA bus.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/service-alerts
     ///
-    /// - parameter completion: Completion handler which returns `TransitRealtime_FeedMessage`
-    func alerts(completion: @escaping (Result<TransitRealtime_FeedMessage, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - completion: A completion handler
+    ///     - result: `TransitRealtime_FeedMessage` if successful, otherwise `WMATAError`
+    func alerts(completion: @escaping (_ result: Result<TransitRealtime_FeedMessage, WMATAError>) -> Void) {
         fetch(
             request: URLRequest(url: GTFSRTBusURL.alerts.rawValue, key: key),
             session: session,
@@ -333,8 +383,10 @@ public extension MetroBus {
     /// GTFS RT 2.0 trip updates feed for WMATA bus.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/trip-updates
     ///
-    /// - parameter completion: Completion handler which returns `TransitRealtime_FeedMessage`
-    func tripUpdates(completion: @escaping (Result<TransitRealtime_FeedMessage, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - completion: A completion handler
+    ///     - result: `TransitRealtime_FeedMessage` if successful, otherwise `WMATAError`
+    func tripUpdates(completion: @escaping (_ result: Result<TransitRealtime_FeedMessage, WMATAError>) -> Void) {
         fetch(
             request: URLRequest(
                 url: GTFSRTBusURL.tripUpdates.rawValue,
@@ -361,8 +413,10 @@ public extension MetroBus {
     /// GTFS RT 2.0 vehicle positions feed for WMATA bus.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions
     ///
-    /// - parameter completion: Completion handler which returns `TransitRealtime_FeedMessage`
-    func vehiclePositions(completion: @escaping (Result<TransitRealtime_FeedMessage, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - completion: A completion handler
+    ///     - result: `TransitRealtime_FeedMessage` if successful, otherwise `WMATAError`
+    func vehiclePositions(completion: @escaping (_ result: Result<TransitRealtime_FeedMessage, WMATAError>) -> Void) {
         fetch(
             request: URLRequest(url: GTFSRTBusURL.vehiclePositions.rawValue, key: key),
             session: session,
@@ -389,7 +443,7 @@ public extension MetroBus {
     /// GTFS RT 2.0 service alerts feed for WMATA bus.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/service-alerts
     ///
-    /// - returns: A Combine Publisher for `TransitRealtime_FeedMessage`
+    /// - Returns: A Combine Publisher for `TransitRealtime_FeedMessage`
     func alertsPublisher() -> AnyPublisher<TransitRealtime_FeedMessage, WMATAError> {
         publisher(
             request: URLRequest(
@@ -403,7 +457,7 @@ public extension MetroBus {
     /// GTFS RT 2.0 trip updates feed for WMATA bus.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/trip-updates
     ///
-    /// - returns: A Combine Publisher for `TransitRealtime_FeedMessage`
+    /// - Returns: A Combine Publisher for `TransitRealtime_FeedMessage`
     func tripUpdatesPublisher() -> AnyPublisher<TransitRealtime_FeedMessage, WMATAError> {
         publisher(
             request: URLRequest(
@@ -417,7 +471,7 @@ public extension MetroBus {
     /// GTFS RT 2.0 vehicle positions feed for WMATA bus.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions
     ///
-    /// - returns: A Combine Publisher for`TransitRealtime_FeedMessage`
+    /// - Returns: A Combine Publisher for`TransitRealtime_FeedMessage`
     func vehiclePositionsPublisher() -> AnyPublisher<TransitRealtime_FeedMessage, WMATAError> {
         publisher(
             request: URLRequest(

--- a/Sources/WMATA/MetroBus.swift
+++ b/Sources/WMATA/MetroBus.swift
@@ -54,7 +54,7 @@ public struct MetroBus: Fetcher {
 // These don't require any Route or Stop IDs
 public extension MetroBus {
     /// All bus routes and variants
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     func routes() {
         request(
             request: URLRequest(url: BusURL.routes.rawValue, key: key),
@@ -76,11 +76,11 @@ public extension MetroBus {
     }
 
     /// Stops nearby the given latitude, longitude and radius. Omit latitude, longitude and radius to receive all stops.
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
     /// - Parameters:
-    /// - radiusAtCoordinates: Radius at latitude and longitude to search at
-    func searchStops(at radiusAtCoordinates: RadiusAtCoordinates?) {
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
+    func searchStops(at radiusAtCoordinates: RadiusAtCoordinates? = nil) {
         var queryItems = [(String, String)]()
 
         if let radiusAtCoordinates = radiusAtCoordinates {
@@ -99,7 +99,7 @@ public extension MetroBus {
     ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
     ///     - completion: A completion handler
     ///     - result: [StopsSearchResponse](x-source-tag://StopsSearchResponse) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
-    func searchStops(at radiusAtCoordinates: RadiusAtCoordinates?, completion: @escaping (_ result: Result<StopsSearchResponse, WMATAError>) -> Void) {
+    func searchStops(at radiusAtCoordinates: RadiusAtCoordinates? = nil, completion: @escaping (_ result: Result<StopsSearchResponse, WMATAError>) -> Void) {
         var queryItems = [(String, String)]()
 
         if let radiusAtCoordinates = radiusAtCoordinates {
@@ -132,7 +132,7 @@ public extension MetroBus {
     ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
     ///
     /// - Returns: A Combine Publisher for [StopsSearchResponse](x-source-tag://StopsSearchResponse)
-    func searchStopsPublisher(at radiusAtCoordinates: RadiusAtCoordinates?) -> AnyPublisher<StopsSearchResponse, WMATAError> {
+    func searchStopsPublisher(at radiusAtCoordinates: RadiusAtCoordinates? = nil) -> AnyPublisher<StopsSearchResponse, WMATAError> {
         var queryItems = [(String, String)]()
 
         if let radiusAtCoordinates = radiusAtCoordinates {
@@ -150,12 +150,12 @@ extension MetroBus: NeedsRoute {}
 
 public extension MetroBus {
     /// Bus positions including latlong and direction. Omit routeId, latitude, longitude and radius to receive all bus positions.
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
     /// - Parameters:
     ///     - route: Get bus positions along this route
     ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
-    func positions(on route: Route?, at radiusAtCoordinates: RadiusAtCoordinates?) {
+    func positions(on route: Route? = nil, at radiusAtCoordinates: RadiusAtCoordinates? = nil) {
         (self as NeedsRoute).positions(on: route, at: radiusAtCoordinates, key: key, session: session)
     }
 
@@ -166,16 +166,16 @@ public extension MetroBus {
     ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
     ///     - completion: Completion handler which returns `BusPositions`
     ///     - result: [BusPositions](x-source-tag://BusPositions) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
-    func positions(on route: Route?, at radiusAtCoordinates: RadiusAtCoordinates?, completion: @escaping (_ result: Result<BusPositions, WMATAError>) -> Void) {
+    func positions(on route: Route? = nil, at radiusAtCoordinates: RadiusAtCoordinates? = nil, completion: @escaping (_ result: Result<BusPositions, WMATAError>) -> Void) {
         (self as NeedsRoute).positions(on: route, at: radiusAtCoordinates, key: key, session: session, completion: completion)
     }
 
     /// Bus incidents along a given route.
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
     /// - Parameters:
     ///     - route: Route to search for incidents along. Omit route to receive all incidents.
-    func incidents(on route: Route?) {
+    func incidents(on route: Route? = nil) {
         (self as NeedsRoute).incidents(on: route, key: key, session: session)
     }
 
@@ -185,12 +185,12 @@ public extension MetroBus {
     ///     - route: Route to search for incidents along. Omit route to receive all incidents.
     ///     - completion: A completion handler
     ///     - result: [BusIncidents](x-source-tag://BusIncidents) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
-    func incidents(on route: Route?, completion: @escaping (_ result: Result<BusIncidents, WMATAError>) -> Void) {
+    func incidents(on route: Route? = nil, completion: @escaping (_ result: Result<BusIncidents, WMATAError>) -> Void) {
         (self as NeedsRoute).incidents(on: route, key: key, session: session, completion: completion)
     }
 
     /// Ordered latlong points along this Route for a given date. Omit date to get path information for today.
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
     /// - Parameters:
     ///     - route: Route to get path details for
@@ -211,7 +211,7 @@ public extension MetroBus {
     }
 
     /// Scheduled stops for this Route
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
     /// - Parameters:
     ///     - route: Route to get stops for
@@ -243,7 +243,7 @@ public extension MetroBus {
     ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
     ///
     /// - Returns: A Combine Publisher for [BusPositions](x-source-tag://BusPositions)
-    func positionsPublisher(on route: Route?, at radiusAtCoordinates: RadiusAtCoordinates?) -> AnyPublisher<BusPositions, WMATAError> {
+    func positionsPublisher(on route: Route? = nil, at radiusAtCoordinates: RadiusAtCoordinates? = nil) -> AnyPublisher<BusPositions, WMATAError> {
         (self as NeedsRoute).positionsPublisher(on: route, at: radiusAtCoordinates, key: key, session: session)
     }
 
@@ -253,7 +253,7 @@ public extension MetroBus {
     ///     - route: Route to search for incidents along. Omit route to receive all incidents.
     ///
     /// - Returns: A Combine Publisher for [BusIncidents](x-source-tag://BusIncidents)
-    func incidentsPublisher(on route: Route?) -> AnyPublisher<BusIncidents, WMATAError> {
+    func incidentsPublisher(on route: Route? = nil) -> AnyPublisher<BusIncidents, WMATAError> {
         (self as NeedsRoute).incidentsPublisher(on: route, key: key, session: session)
     }
 
@@ -285,7 +285,7 @@ extension MetroBus: NeedsStop {}
 
 public extension MetroBus {
     /// Next bus arrival times at this Stop
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
     /// - Parameters:
     ///     - stop: Stop to get next arrival times for
@@ -304,7 +304,7 @@ public extension MetroBus {
     }
 
     /// Set of buses scheduled to arrive at this Stop at a given date.
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
     /// - Parameters:
     ///     - stop: Stop to get schedule for
@@ -369,7 +369,7 @@ public extension MetroBus {
 
     /// GTFS RT 2.0 service alerts feed for WMATA bus.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/service-alerts
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     func alerts() {
         request(
             request: URLRequest(
@@ -399,7 +399,7 @@ public extension MetroBus {
 
     /// GTFS RT 2.0 trip updates feed for WMATA bus.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/trip-updates
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     func tripUpdates() {
         request(
             request: URLRequest(
@@ -426,7 +426,7 @@ public extension MetroBus {
 
     /// GTFS RT 2.0 vehicle positions feed for WMATA bus.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     func vehiclePositions() {
         request(
             request: URLRequest(

--- a/Sources/WMATA/MetroBus.swift
+++ b/Sources/WMATA/MetroBus.swift
@@ -54,7 +54,10 @@ public struct MetroBus: Fetcher {
 // These don't require any Route or Stop IDs
 public extension MetroBus {
     /// All bus routes and variants
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateRoutesResponse)
     ///
     /// - Note:
     ///     [WMATA Routes Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6a)
@@ -82,7 +85,10 @@ public extension MetroBus {
     }
 
     /// Stops nearby the given latitude, longitude and radius. Omit latitude, longitude and radius to receive all stops.
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateStopsSearchResponse)
     ///
     /// - Note:
     ///     [WMATA Search Stop Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6d)
@@ -168,7 +174,10 @@ extension MetroBus: NeedsRoute {}
 
 public extension MetroBus {
     /// Bus positions including latlong and direction. Omit routeId, latitude, longitude and radius to receive all bus positions.
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateBusPositions)
     ///
     /// - Note:
     ///     [WMATA Positions Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d68)
@@ -195,7 +204,10 @@ public extension MetroBus {
     }
 
     /// Bus incidents along a given route.
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateBusIncidents)
     ///
     /// - Note:
     ///     [WMATA Incidents Documentation](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d75)
@@ -220,7 +232,10 @@ public extension MetroBus {
     }
 
     /// Ordered latlong points along this Route for a given date. Omit date to get path information for today.
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegatePathDetails)
     ///
     /// - Note:
     ///     [WMATA Path Details Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d69)
@@ -247,7 +262,10 @@ public extension MetroBus {
     }
 
     /// Scheduled stops for this Route
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateRouteSchedule)
     ///
     /// - Note:
     ///     [WMATA Route Schedule Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6b)
@@ -339,7 +357,10 @@ extension MetroBus: NeedsStop {}
 
 public extension MetroBus {
     /// Next bus arrival times at this Stop
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateBusPredictions)
     ///
     /// - Note:
     ///     [WMATA Next Buses Documentation](https://developer.wmata.com/docs/services/5476365e031f590f38092508/operations/5476365e031f5909e4fe331d)
@@ -364,7 +385,10 @@ public extension MetroBus {
     }
 
     /// Set of buses scheduled to arrive at this Stop at a given date.
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateStopSchedule)
     ///
     /// - Note:
     ///     [WMATA Stop Schedule Documentation](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6c)
@@ -442,7 +466,10 @@ public extension MetroBus {
     }
 
     /// GTFS RT 2.0 service alerts feed for WMATA bus.
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateAlerts)
     ///
     /// - Note:
     ///     [Google Alerts Documentation](https://developers.google.com/transit/gtfs-realtime/guides/service-alerts)
@@ -476,7 +503,10 @@ public extension MetroBus {
     }
 
     /// GTFS RT 2.0 trip updates feed for WMATA bus.
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateTripUpdates)
     ///
     /// - Note:
     ///     [Google Trip Updates Documentation](https://developers.google.com/transit/gtfs-realtime/guides/trip-updates)
@@ -507,7 +537,10 @@ public extension MetroBus {
     }
 
     /// GTFS RT 2.0 vehicle positions feed for WMATA
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateVehiclePositions)
     ///
     /// - Note:
     ///     [Google Vehicle Positions Documentation](https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions)

--- a/Sources/WMATA/MetroRail.swift
+++ b/Sources/WMATA/MetroRail.swift
@@ -9,9 +9,12 @@ import Combine
 import Foundation
 import GTFS
 
-/// MetroRail related methods
+/// For accessing MetroRail related APIs
 public struct MetroRail: Fetcher {
+    /// WMATA API Key
     public let key: String
+    
+    /// Delegate for use with delegate calls
     public var delegate: WMATADelegate? {
         didSet {
             if let delegate = self.delegate {
@@ -20,10 +23,18 @@ public struct MetroRail: Fetcher {
         }
     }
 
+    /// The shared container identifier for use with app extensions. See [URLSessionConfiguration](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1409450-sharedcontaineridentifier)
     public private(set) var sharedContainerIdentifier: String?
 
+    /// URL session to use for all calls
     private var urlSession: URLSession
 
+    /// Create a new MetroRail instance
+    ///
+    /// - Parameters:
+    ///     - key: Your WMATA API key
+    ///     - delegate: The delegate to use for all delegate calls
+    ///     - sharedContainerIdentifier: Identifier for use with app extensions
     public init(key: String, delegate: WMATADelegate? = nil, sharedContainerIdentifier: String? = nil) {
         self.key = key
 
@@ -43,7 +54,7 @@ public struct MetroRail: Fetcher {
 // These don't require a Station or Line
 public extension MetroRail {
     /// General information on all MetroRail lines
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     func lines() {
         request(
             request: URLRequest(url: RailURL.lines.rawValue, key: key),
@@ -53,8 +64,10 @@ public extension MetroRail {
 
     /// General information on all MetroRail lines
     ///
-    /// - parameter completion: Completion handler which returns `LinesResponse`
-    func lines(completion: @escaping (Result<LinesResponse, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - completion: A completion handler
+    ///     - result: [LinesResponse](x-source-tag://LinesResponse) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func lines(completion: @escaping (_ result: Result<LinesResponse, WMATAError>) -> Void) {
         fetch(
             request: URLRequest(url: RailURL.lines.rawValue, key: key),
             session: urlSession,
@@ -63,10 +76,11 @@ public extension MetroRail {
     }
 
     /// Station entrances within a radius of a lat long pair, omit all parameters to receive all entrances
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
-    /// - parameter radiusAtCoordinates:`RadiusAtCoordinates` to search at
-    func entrances(at radiusAtCoordinates: RadiusAtCoordinates?) {
+    /// - Parameters:
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
+    func entrances(at radiusAtCoordinates: RadiusAtCoordinates? = nil) {
         var queryItems = [(String, String)]()
 
         if let radiusAtCoordinates = radiusAtCoordinates {
@@ -81,9 +95,11 @@ public extension MetroRail {
 
     /// Station entrances within a radius of a lat long pair, omit all parameters to receive all entrances
     ///
-    /// - parameter radiusAtCoordinates:`RadiusAtCoordinates` to search at
-    /// - parameter completion: Completion handler which returns `StationEntrances`
-    func entrances(at radiusAtCoordinates: RadiusAtCoordinates?, completion: @escaping (Result<StationEntrances, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
+    ///     - completion: A completion handler
+    ///     - result: [StationEntrances](x-source-tag://StationEntrances) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func entrances(at radiusAtCoordinates: RadiusAtCoordinates? = nil, completion: @escaping (_ result: Result<StationEntrances, WMATAError>) -> Void) {
         var queryItems = [(String, String)]()
 
         if let radiusAtCoordinates = radiusAtCoordinates {
@@ -98,7 +114,7 @@ public extension MetroRail {
     }
 
     /// Uniquely identifiable trains in service and what track circuits they currently occupy
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     func positions() {
         request(
             request: URLRequest(url: RailURL.positions.rawValue, key: key, queryItems: [("contentType", "json")]),
@@ -108,8 +124,10 @@ public extension MetroRail {
 
     /// Uniquely identifiable trains in service and what track circuits they currently occupy
     ///
-    /// - parameter completion: Completion handler which returns `TrainPositions`
-    func positions(completion: @escaping (Result<TrainPositions, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - completion: A completion handler
+    ///     - result: [TrainPositions](x-source-tag://TrainPositions) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func positions(completion: @escaping (_ result: Result<TrainPositions, WMATAError>) -> Void) {
         fetch(
             request: URLRequest(url: RailURL.positions.rawValue, key: key, queryItems: [("contentType", "json")]),
             session: urlSession,
@@ -118,7 +136,7 @@ public extension MetroRail {
     }
 
     /// Ordered list of track circuits, arranged by line and track number
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     func routes() {
         request(
             request: URLRequest(url: RailURL.routes.rawValue, key: key, queryItems: [("contentType", "json")]),
@@ -128,8 +146,10 @@ public extension MetroRail {
 
     /// Ordered list of track circuits, arranged by line and track number
     ///
-    /// - parameter completion: Completion handler which returns `StandardRoutes`
-    func routes(completion: @escaping (Result<StandardRoutes, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - completion: A completion handler
+    ///     - result: [StandardRoutes](x-source-tag://StandardRoutes) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func routes(completion: @escaping (_ result: Result<StandardRoutes, WMATAError>) -> Void) {
         fetch(
             request: URLRequest(url: RailURL.routes.rawValue, key: key, queryItems: [("contentType", "json")]),
             session: urlSession,
@@ -138,7 +158,7 @@ public extension MetroRail {
     }
 
     /// List of all track circuits - See https://developer.wmata.com/TrainPositionsFAQ
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     func circuits() {
         request(
             request: URLRequest(url: RailURL.circuits.rawValue, key: key, queryItems: [("contentType", "json")]),
@@ -148,8 +168,10 @@ public extension MetroRail {
 
     /// List of all track circuits - See https://developer.wmata.com/TrainPositionsFAQ
     ///
-    /// - parameter completion: Completion handler which returns `TrackCircuits`
-    func circuits(completion: @escaping (Result<TrackCircuits, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - completion: A completion handler
+    ///     - result: [TrackCircuits](x-source-tag://TrackCircuits) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func circuits(completion: @escaping (_ result: Result<TrackCircuits, WMATAError>) -> Void) {
         fetch(
             request: URLRequest(url: RailURL.circuits.rawValue, key: key, queryItems: [("contentType", "json")]),
             session: urlSession,
@@ -163,7 +185,7 @@ public extension MetroRail {
 public extension MetroRail {
     /// General information on all MetroRail lines
     ///
-    /// - returns: A Combine Publisher for `LinesResponse`
+    /// - Returns: A Combine Publisher for [LinesResponse](x-source-tag://LinesResponse)
     func linesPublisher() -> AnyPublisher<LinesResponse, WMATAError> {
         publisher(
             request: URLRequest(url: RailURL.lines.rawValue, key: key),
@@ -173,9 +195,11 @@ public extension MetroRail {
 
     /// Station entrances within a radius of a lat long pair, omit all parameters to receive all entrances
     ///
-    /// - parameter radiusAtCoordinates:`RadiusAtCoordinates` to search at
-    /// - returns: A Combine Publisher for `StationEntrances`
-    func entrancesPublisher(at radiusAtCoordinates: RadiusAtCoordinates?) -> AnyPublisher<StationEntrances, WMATAError> {
+    /// - Parameters:
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
+    ///
+    /// - Returns: A Combine Publisher for [StationEntrances](x-source-tag://StationEntrances)
+    func entrancesPublisher(at radiusAtCoordinates: RadiusAtCoordinates? = nil) -> AnyPublisher<StationEntrances, WMATAError> {
         var queryItems = [(String, String)]()
 
         if let radiusAtCoordinates = radiusAtCoordinates {
@@ -190,7 +214,7 @@ public extension MetroRail {
 
     /// Uniquely identifiable trains in service and what track circuits they currently occupy
     ///
-    /// - returns: A Combine Publisher for `TrainPositions`
+    /// - Returns: A Combine Publisher for [TrainPositions](x-source-tag://TrainPositions)
     func positionsPublisher() -> AnyPublisher<TrainPositions, WMATAError> {
         publisher(
             request: URLRequest(url: RailURL.positions.rawValue, key: key, queryItems: [("contentType", "json")]),
@@ -200,7 +224,7 @@ public extension MetroRail {
 
     /// Ordered list of track circuits, arranged by line and track number
     ///
-    /// - returns: A Combine Publisher for `StandardRoutes`
+    /// - Returns: A Combine Publisher for [StandardRoutes](x-source-tag://StandardRoutes)
     func routesPublisher() -> AnyPublisher<StandardRoutes, WMATAError> {
         publisher(
             request: URLRequest(url: RailURL.routes.rawValue, key: key, queryItems: [("contentType", "json")]),
@@ -210,7 +234,7 @@ public extension MetroRail {
 
     /// List of all track circuits - See https://developer.wmata.com/TrainPositionsFAQ
     ///
-    /// - returns: A Combine Publisher for `TrackCircuits`
+    /// - Returns: A Combine Publisher for [TrackCircuits](x-source-tag://TrackCircuits)
     func circuitsPublisher() -> AnyPublisher<TrackCircuits, WMATAError> {
         publisher(
             request: URLRequest(url: RailURL.circuits.rawValue, key: key, queryItems: [("contentType", "json")]),
@@ -223,150 +247,177 @@ extension MetroRail: NeedsStation {}
 
 public extension MetroRail {
     /// Distance, fare information, and estimated travel time between any two stations. Omit both station codes to receive information for all possible trips.
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
-    /// - parameter station: Station to start trip at
-    /// - parameter destinationStation: Station to travel to
-    func station(_ station: Station?, to destinationStation: Station?) {
+    /// - Parameters:
+    ///     - station: Station to start trip at
+    ///     - destinationStation: Station to travel to
+    func station(_ station: Station? = nil, to destinationStation: Station? = nil) {
         (self as NeedsStation).station(station, to: destinationStation, key: key, session: urlSession)
     }
 
     /// Distance, fare information, and estimated travel time between any two stations. Omit both station codes to receive information for all possible trips.
     ///
-    /// - parameter station: Station to start trip at
-    /// - parameter destinationStation: Station to travel to
-    /// - parameter completion: Completion handler which returns `StationToStationInfos`
-    func station(_ station: Station?, to destinationStation: Station?, completion: @escaping (Result<StationToStationInfos, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - station: Station to start trip at
+    ///     - destinationStation: Station to travel to
+    ///     - completion: A completion handler
+    ///     - result: [StationToStationInfos](x-source-tag://StationToStationInfos) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func station(_ station: Station? = nil, to destinationStation: Station? = nil, completion: @escaping (_ result: Result<StationToStationInfos, WMATAError>) -> Void) {
         (self as NeedsStation).station(station, to: destinationStation, key: key, session: urlSession, completion: completion)
     }
 
     /// Reported elevator and escalator incidents
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
-    /// - parameter station: Which station to search for incidents at. Optional.
-    func elevatorAndEscalatorIncidents(at station: Station?) {
+    /// - Parameters:
+    ///     - station: Which station to search for incidents at. Optional.
+    func elevatorAndEscalatorIncidents(at station: Station? = nil) {
         (self as NeedsStation).elevatorAndEscalatorIncidents(at: station, key: key, session: urlSession)
     }
 
     /// Reported elevator and escalator incidents
     ///
-    /// - parameter station: Which station to search for incidents at. Optional.
-    /// - parameter completion: Completion handler which returns `ElevatorAndEscalatorIncidents`
-    func elevatorAndEscalatorIncidents(at station: Station?, completion: @escaping (Result<ElevatorAndEscalatorIncidents, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - station: Which station to search for incidents at. Optional.
+    ///     - completion: A completion handler
+    ///     - result: [ElevatorAndEscalatorIncidents](x-source-tag://ElevatorAndEscalatorIncidents) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func elevatorAndEscalatorIncidents(at station: Station? = nil, completion: @escaping (_ result: Result<ElevatorAndEscalatorIncidents, WMATAError>) -> Void) {
         (self as NeedsStation).elevatorAndEscalatorIncidents(at: station, key: key, session: urlSession, completion: completion)
     }
 
     /// Reported MetroRail incidents
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
-    /// - parameter station: Station to search for incidents at. Optional.
-    func incidents(at station: Station?) {
+    /// - Parameters:
+    ///     - station: Station to search for incidents at. Optional.
+    func incidents(at station: Station? = nil) {
         (self as NeedsStation).incidents(at: station, key: key, session: urlSession)
     }
 
     /// Reported MetroRail incidents
     ///
-    /// - parameter station: Station to search for incidents at. Optional.
-    /// - parameter completion: Completion handler which returns `RailIncidents`
-    func incidents(at station: Station?, completion: @escaping (Result<RailIncidents, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - station: Station to search for incidents at. Optional.
+    ///     - completion: A completion handler
+    ///     - result: [RailIncidents](x-source-tag://RailIncidents) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func incidents(at station: Station? = nil, completion: @escaping (_ result: Result<RailIncidents, WMATAError>) -> Void) {
         (self as NeedsStation).incidents(at: station, key: key, session: urlSession, completion: completion)
     }
 
     /// Next train arrival information for this station
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
-    /// - parameter station: `Station` to search for trains at
+    /// - Parameters:
+    ///     - station: Station to search for trains at
     func nextTrains(at station: Station) {
         (self as NeedsStation).nextTrains(at: station, key: key, session: urlSession)
     }
 
     /// Next train arrival information for this station
     ///
-    /// - parameter station: `Station` to search for trains at
-    /// - parameter completion: Completion handler which returns `RailPredictions`
-    func nextTrains(at station: Station, completion: @escaping (Result<RailPredictions, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - station: `Station` to search for trains at
+    ///     - completion: A completion handler
+    ///     - result: [RailPredictions](x-source-tag://RailPredictions) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func nextTrains(at station: Station, completion: @escaping (_ result: Result<RailPredictions, WMATAError>) -> Void) {
         (self as NeedsStation).nextTrains(at: station, key: key, session: urlSession, completion: completion)
     }
 
     /// Next train arrival information for the given stations
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
-    /// - parameter stations: `[Station]`s to look up next trains for
+    /// - Parameters:
+    ///     - stations: Stations to look up next trains for
     func nextTrains(at stations: [Station]) {
         (self as NeedsStation).nextTrains(at: stations, key: key, session: urlSession)
     }
 
     /// Next train arrival information for the given stations
     ///
-    /// - parameter stations: `[Station]`s to look up next trains for
-    /// - parameter completion: Completion handler which returns `RailPredictions`
-    func nextTrains(at stations: [Station], completion: @escaping (Result<RailPredictions, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - stations: Stations to look up next trains for
+    ///     - completion: A completion handler
+    ///     - result: [RailPredictions](x-source-tag://RailPredictions) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func nextTrains(at stations: [Station], completion: @escaping (_ result: Result<RailPredictions, WMATAError>) -> Void) {
         (self as NeedsStation).nextTrains(at: stations, key: key, session: urlSession, completion: completion)
     }
 
     /// Location and address information for this station
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
-    /// - parameter station: `StationCode` search for information for
+    /// - Parameters:
+    ///     - station: Station to search for information on
     func information(for station: Station) {
         (self as NeedsStation).information(for: station, key: key, session: urlSession)
     }
 
     /// Location and address information for this station
     ///
-    /// - parameter station: `StationCode` search for information for
-    /// - parameter completion: Completion handler which returns `StationInformation`
-    func information(for station: Station, completion: @escaping (Result<StationInformation, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - station: Station to search for information on
+    ///     - completion: A completion handler
+    ///     - result: [StationInformation](x-source-tag://StationInformation) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func information(for station: Station, completion: @escaping (_ result: Result<StationInformation, WMATAError>) -> Void) {
         (self as NeedsStation).information(for: station, key: key, session: urlSession, completion: completion)
     }
 
     /// Parking information for this station
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
-    /// - parameter station: `StationCode` to search for parking information for
+    /// - Parameters:
+    ///     - station: Station to search for parking information on
     func parkingInformation(for station: Station) {
         (self as NeedsStation).parkingInformation(for: station, key: key, session: urlSession)
     }
 
     /// Parking information for this station
     ///
-    /// - parameter station: `StationCode` to search for parking information for
-    /// - parameter completion: Completion handler which returns `StationsParking`
-    func parkingInformation(for station: Station, completion: @escaping (Result<StationsParking, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - station: Station  to search for parking information on
+    ///     - completion: A completion handler
+    ///     - result: [StationsParking](x-source-tag://StationsParking) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func parkingInformation(for station: Station, completion: @escaping (_ result: Result<StationsParking, WMATAError>) -> Void) {
         (self as NeedsStation).parkingInformation(for: station, key: key, session: urlSession, completion: completion)
     }
 
     /// Returns a set of ordered stations and distances between two stations _on the same line_
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
-    /// - parameter startingStation: Starting station to pathfind from
-    /// - parameter destinationStation: Destination station to pathfind to
+    /// - Parameters:
+    ///     - startingStation: Starting station to pathfind from
+    ///     - destinationStation: Destination station to pathfind to
     func path(from startingStation: Station, to destinationStation: Station) {
         (self as NeedsStation).path(from: startingStation, to: destinationStation, key: key, session: urlSession)
     }
 
     /// Returns a set of ordered stations and distances between two stations _on the same line_
     ///
-    /// - parameter startingStation: Starting station to pathfind from
-    /// - parameter destinationStation: Destination station to pathfind to
-    /// - parameter completion: Completion handler which returns `PathBetweenStations`
-    func path(from startingStation: Station, to destinationStation: Station, completion: @escaping (Result<PathBetweenStations, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - startingStation: Starting station to pathfind from
+    ///     - destinationStation: Destination station to pathfind to
+    ///     - completion: A completion handler
+    ///     - result: [PathBetweenStations](x-source-tag://PathBetweenStations) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func path(from startingStation: Station, to destinationStation: Station, completion: @escaping (_ result: Result<PathBetweenStations, WMATAError>) -> Void) {
         (self as NeedsStation).path(from: startingStation, to: destinationStation, key: key, session: urlSession, completion: completion)
     }
 
     /// Opening and scheduled first and last trains for this station
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
-    /// - parameter station: `StationCode` to search for timings for
+    /// - Parameters:
+    ///     - station: Station to search for timings on
     func timings(for station: Station) {
         (self as NeedsStation).timings(for: station, key: key, session: urlSession)
     }
 
     /// Opening and scheduled first and last trains for this station
     ///
-    /// - parameter station: `StationCode` to search for timings for
-    /// - parameter completion: Completion handler which returns `StationTimings`
-    func timings(for station: Station, completion: @escaping (Result<StationTimings, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - station: Station to search for timings on
+    ///     - completion: Completion handler which returns `StationTimings`
+    ///     - result: [StationTimings](x-source-tag://StationTimings) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func timings(for station: Station, completion: @escaping (_ result: Result<StationTimings, WMATAError>) -> Void) {
         (self as NeedsStation).timings(for: station, key: key, session: urlSession, completion: completion)
     }
 }
@@ -375,74 +426,92 @@ public extension MetroRail {
 public extension MetroRail {
     /// Distance, fare information, and estimated travel time between any two stations. Omit both station codes to receive information for all possible trips.
     ///
-    /// - parameter station: Station to start trip at
-    /// - parameter destinationStation: Station to travel to
-    /// - returns: A Combine Publisher for `StationToStationInfos`
-    func stationPublisher(_ station: Station?, to destinationStation: Station?) -> AnyPublisher<StationToStationInfos, WMATAError> {
+    /// - Parameters:
+    ///     - station: Station to start trip at
+    ///     - destinationStation: Station to travel to
+    ///
+    /// - Returns: A Combine Publisher for [StationToStationInfos](x-source-tag://StationToStationInfos)
+    func stationPublisher(_ station: Station? = nil, to destinationStation: Station? = nil) -> AnyPublisher<StationToStationInfos, WMATAError> {
         (self as NeedsStation).stationPublisher(station, to: destinationStation, key: key, session: urlSession)
     }
 
     /// Reported elevator and escalator incidents
     ///
-    /// - parameter station: Which station to search for incidents at. Optional.
-    /// - returns: A Combine Publisher for `ElevatorAndEscalatorIncidents`
-    func elevatorAndEscalatorIncidentsPublisher(at station: Station?) -> AnyPublisher<ElevatorAndEscalatorIncidents, WMATAError> {
+    /// - Parameters:
+    ///     - station: Which station to search for incidents at. Optional.
+    ///
+    /// - Returns: A Combine Publisher for [ElevatorAndEscalatorIncidents](x-source-tag://ElevatorAndEscalatorIncidents)
+    func elevatorAndEscalatorIncidentsPublisher(at station: Station? = nil) -> AnyPublisher<ElevatorAndEscalatorIncidents, WMATAError> {
         (self as NeedsStation).elevatorAndEscalatorIncidentsPublisher(at: station, key: key, session: urlSession)
     }
 
     /// Reported MetroRail incidents
     ///
-    /// - parameter station: Station to search for incidents at. Optional.
-    /// - returns: A Combine Publisher for `RailIncidents`
-    func incidentsPublisher(at station: Station?) -> AnyPublisher<RailIncidents, WMATAError> {
+    /// - Parameters:
+    ///     - station: Station to search for incidents at. Optional.
+    ///
+    /// - Returns: A Combine Publisher for [RailIncidents](x-source-tag://RailIncidents)
+    func incidentsPublisher(at station: Station? = nil) -> AnyPublisher<RailIncidents, WMATAError> {
         (self as NeedsStation).incidentsPublisher(at: station, key: key, session: urlSession)
     }
 
     /// Next train arrival information for this station
     ///
-    /// - parameter station: `Station` to search for trains at
-    /// - returns: A Combine Publisher for  `RailPredictions`
+    /// - Parameters:
+    ///     - station: Station to search for trains at
+    ///
+    /// - Returns: A Combine Publisher for [RailPredictions](x-source-tag://RailPredictions)
     func nextTrainsPublisher(at station: Station) -> AnyPublisher<RailPredictions, WMATAError> {
         (self as NeedsStation).nextTrainsPublisher(at: station, key: key, session: urlSession)
     }
 
     /// Next train arrival information for the given stations
     ///
-    /// - parameter stations: `[Station]`s to look up next trains for
-    /// - returns: A Combine Publisher for  `RailPredictions`
+    /// - Parameters:
+    ///     - stations: Stations to look up next trains for
+    ///
+    /// - Returns: A Combine Publisher for  [RailPredictions](x-source-tag://RailPredictions)
     func nextTrainsPublisher(at stations: [Station]) -> AnyPublisher<RailPredictions, WMATAError> {
         (self as NeedsStation).nextTrainsPublisher(at: stations, key: key, session: urlSession)
     }
 
     /// Location and address information for this station
     ///
-    /// - parameter station: `StationCode` search for information for
-    /// - returns: A Combine Publisher for `StationInformation`
+    /// - Parameters:
+    ///     - station: Station search for information on
+    ///
+    /// - Returns: A Combine Publisher for  [StationInformation](x-source-tag://StationInformation)
     func informationPublisher(for station: Station) -> AnyPublisher<StationInformation, WMATAError> {
         (self as NeedsStation).informationPublisher(for: station, key: key, session: urlSession)
     }
 
     /// Parking information for this station
     ///
-    /// - parameter station: `StationCode` to search for parking information for
-    /// - returns: A Combine Publisher for `StationsParking`
+    /// - Parameters:
+    ///     - station: Station to search for parking information on
+    ///
+    /// - Returns: A Combine Publisher for [StationsParking](x-source-tag://StationsParking)
     func parkingInformationPublisher(for station: Station) -> AnyPublisher<StationsParking, WMATAError> {
         (self as NeedsStation).parkingInformationPublisher(for: station, key: key, session: urlSession)
     }
 
     /// Returns a set of ordered stations and distances between two stations _on the same line_
     ///
-    /// - parameter startingStation: Starting station to pathfind from
-    /// - parameter destinationStation: Destination station to pathfind to
-    /// - returns: A Combine Publisher for  `PathBetweenStations`
+    /// - Parameters:
+    ///     - startingStation: Starting station to pathfind from
+    ///     - destinationStation: Destination station to pathfind to
+    ///
+    /// - Returns: A Combine Publisher for  [PathBetweenStations](x-source-tag://PathBetweenStations)
     func pathPublisher(from startingStation: Station, to destinationStation: Station) -> AnyPublisher<PathBetweenStations, WMATAError> {
         (self as NeedsStation).pathPublisher(from: startingStation, to: destinationStation, key: key, session: urlSession)
     }
 
     /// Opening and scheduled first and last trains for this station
     ///
-    /// - parameter station: `StationCode` to search for timings for
-    /// - returns: A Combine Publisher for  `StationTimings`
+    /// - Parameters:
+    ///     - station: Station to search for timings for
+    ///
+    /// - Returns: A Combine Publisher for  [StationTimings](x-source-tag://StationTimings)
     func timingsPublisher(for station: Station) -> AnyPublisher<StationTimings, WMATAError> {
         (self as NeedsStation).timingsPublisher(for: station, key: key, session: urlSession)
     }
@@ -452,18 +521,21 @@ extension MetroRail: NeedsLine {}
 
 public extension MetroRail {
     /// Stations along a Line
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
-    /// - parameter line: Line to receive stations along. Omit to receive all stations.
-    func stations(for line: Line?) {
+    /// - Parameters:
+    ///     - line: Line to receive stations along. Omit to receive all stations.
+    func stations(for line: Line? = nil) {
         (self as NeedsLine).stations(for: line, key: key, session: urlSession)
     }
 
     /// Stations along a Line
     ///
-    /// - parameter line: Line to receive stations along. Omit to receive all stations.
-    /// - parameter completion: Completion handler which returns `Stations`
-    func stations(for line: Line?, completion: @escaping (Result<Stations, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - line: Line to receive stations along. Omit to receive all stations.
+    ///     - completion: A completion handler
+    ///     - result: [Stations](x-source-tag://Stations) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func stations(for line: Line? = nil, completion: @escaping (_ result: Result<Stations, WMATAError>) -> Void) {
         (self as NeedsLine).stations(for: line, key: key, session: urlSession, completion: completion)
     }
 }
@@ -472,9 +544,10 @@ public extension MetroRail {
 public extension MetroRail {
     /// Stations along a Line
     ///
-    /// - parameter line: Line to receive stations along. Omit to receive all stations.
-    /// - returns: A Combine Publisher for `Stations`
-    func stationsPublisher(for line: Line?) -> AnyPublisher<Stations, WMATAError> {
+    /// - Parameters:
+    ///     - line: Line to receive stations along. Omit to receive all stations.
+    /// - returns: A Combine Publisher for [Stations](x-source-tag://Stations)
+    func stationsPublisher(for line: Line? = nil) -> AnyPublisher<Stations, WMATAError> {
         (self as NeedsLine).stationsPublisher(for: line, key: key, session: urlSession)
     }
 }
@@ -486,8 +559,10 @@ public extension MetroRail {
     /// GTFS RT 2.0 service alerts feed for WMATA rail.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/service-alerts
     ///
-    /// - parameter completion: Completion handler which returns `TransitRealtime_FeedMessage`
-    func alerts(completion: @escaping (Result<TransitRealtime_FeedMessage, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - completion: A completion handler
+    ///     - result: `TransitRealtime_FeedMessage` if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func alerts(completion: @escaping (_ result: Result<TransitRealtime_FeedMessage, WMATAError>) -> Void) {
         fetch(
             request: URLRequest(url: GTFSRTRailURL.alerts.rawValue, key: key),
             session: urlSession,
@@ -497,7 +572,7 @@ public extension MetroRail {
 
     /// GTFS RT 2.0 service alerts feed for WMATA rail.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/service-alerts
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     func alerts() {
         request(
             request: URLRequest(
@@ -511,8 +586,10 @@ public extension MetroRail {
     /// GTFS RT 2.0 trip updates feed for WMATA rail.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/trip-updates
     ///
-    /// - parameter completion: Completion handler which returns `TransitRealtime_FeedMessage`
-    func tripUpdates(completion: @escaping (Result<TransitRealtime_FeedMessage, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - completion: A completion handler
+    ///     - result: `TransitRealtime_FeedMessage` if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func tripUpdates(completion: @escaping (_ result: Result<TransitRealtime_FeedMessage, WMATAError>) -> Void) {
         fetch(
             request: URLRequest(
                 url: GTFSRTRailURL.tripUpdates.rawValue,
@@ -525,7 +602,7 @@ public extension MetroRail {
 
     /// GTFS RT 2.0 trip updates feed for WMATA rail.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/trip-updates
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     func tripUpdates() {
         request(
             request: URLRequest(
@@ -539,8 +616,10 @@ public extension MetroRail {
     /// GTFS RT 2.0 vehicle positions feed for WMATA rail.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions
     ///
-    /// - parameter completion: Completion handler which returns `TransitRealtime_FeedMessage`
-    func vehiclePositions(completion: @escaping (Result<TransitRealtime_FeedMessage, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - completion: A completion handler
+    ///     - result: `TransitRealtime_FeedMessage` if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func vehiclePositions(completion: @escaping (_ result: Result<TransitRealtime_FeedMessage, WMATAError>) -> Void) {
         fetch(
             request: URLRequest(url: GTFSRTRailURL.vehiclePositions.rawValue, key: key),
             session: urlSession,
@@ -550,7 +629,7 @@ public extension MetroRail {
 
     /// GTFS RT 2.0 vehicle positions feed for WMATA rail.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions
-    /// For use with a `WMATADelegate`
+    /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     func vehiclePositions() {
         request(
             request: URLRequest(
@@ -567,7 +646,7 @@ public extension MetroRail {
     /// GTFS RT 2.0 service alerts feed for WMATA rail.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/service-alerts
     ///
-    /// - returns: A Combine Publisher for `TransitRealtime_FeedMessage`
+    /// - Returns: A Combine Publisher for `TransitRealtime_FeedMessage`
     func alertsPublisher() -> AnyPublisher<TransitRealtime_FeedMessage, WMATAError> {
         publisher(
             request: URLRequest(url: GTFSRTRailURL.alerts.rawValue, key: key),
@@ -578,7 +657,7 @@ public extension MetroRail {
     /// GTFS RT 2.0 trip updates feed for WMATA rail.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/trip-updates
     ///
-    /// - returns: A Combine Publisher for `TransitRealtime_FeedMessage`
+    /// - Returns: A Combine Publisher for `TransitRealtime_FeedMessage`
     func tripUpdatesPublisher() -> AnyPublisher<TransitRealtime_FeedMessage, WMATAError> {
         publisher(
             request: URLRequest(
@@ -592,7 +671,7 @@ public extension MetroRail {
     /// GTFS RT 2.0 vehicle positions feed for WMATA rail.
     /// See https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions
     ///
-    /// - returns: A Combine Publisher for`TransitRealtime_FeedMessage`
+    /// - Returns: A Combine Publisher for`TransitRealtime_FeedMessage`
     func vehiclePositionsPublisher() -> AnyPublisher<TransitRealtime_FeedMessage, WMATAError> {
         publisher(
             request: URLRequest(

--- a/Sources/WMATA/MetroRail.swift
+++ b/Sources/WMATA/MetroRail.swift
@@ -57,6 +57,8 @@ public extension MetroRail {
     ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateLinesResponse)
+    ///
     /// - Note:
     ///     [WMATA Lines API Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330c)
     func lines() {
@@ -83,7 +85,10 @@ public extension MetroRail {
     }
 
     /// Station entrances within a radius of a lat long pair, omit all parameters to receive all entrances
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateStationEntrances)
     ///
     /// - Note:
     ///     [WMATA Entrances Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330f)
@@ -127,7 +132,10 @@ public extension MetroRail {
     }
 
     /// Uniquely identifiable trains in service and what track circuits they currently occupy
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateTrainPositions)
     ///
     /// - Note:
     ///     [WMATA Positions Documentation](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/5763fb35f91823096cac1058)
@@ -155,7 +163,10 @@ public extension MetroRail {
     }
 
     /// Ordered list of track circuits, arranged by line and track number
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateStandardRoutes)
     ///
     /// - Note:
     ///     [WMATA Routes Documentation](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/57641afc031f59363c586dca)
@@ -183,7 +194,10 @@ public extension MetroRail {
     }
 
     /// List of all track circuits - See https://developer.wmata.com/TrainPositionsFAQ
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateTrackCircuits)
     ///
     /// - Note:
     ///     [WMATA Circuits Documentation](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/57644238031f59363c586dcb)
@@ -293,7 +307,10 @@ extension MetroRail: NeedsStation {}
 
 public extension MetroRail {
     /// Distance, fare information, and estimated travel time between any two stations. Omit both station codes to receive information for all possible trips.
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateStationToStationInfos)
     ///
     /// - Note:
     ///     [WMATA Station To Station Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3313)
@@ -320,7 +337,10 @@ public extension MetroRail {
     }
 
     /// Reported elevator and escalator incidents
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateElevatorAndEscalatorIncidents)
     ///
     /// - Note:
     ///     [WMATA Elevator and Escalator Incidents Documentation](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d76)
@@ -345,7 +365,10 @@ public extension MetroRail {
     }
 
     /// Reported MetroRail incidents
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateRailIncidents)
     ///
     /// - Note:
     ///     [WMATA Rail Incidents Documentation](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d77)
@@ -370,7 +393,10 @@ public extension MetroRail {
     }
 
     /// Next train arrival information for this station
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateRailPredictions)
     ///
     /// - Note:
     ///     [WMATA Next Trains Documentation](https://developer.wmata.com/docs/services/547636a6f9182302184cda78/operations/547636a6f918230da855363f)
@@ -395,7 +421,10 @@ public extension MetroRail {
     }
 
     /// Next train arrival information for the given stations
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateRailPredictions)
     ///
     /// - Note:
     ///     [WMATA Next Trains Documentation](https://developer.wmata.com/docs/services/547636a6f9182302184cda78/operations/547636a6f918230da855363f)
@@ -420,7 +449,10 @@ public extension MetroRail {
     }
 
     /// Location and address information for this station
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateStationInformation)
     ///
     /// - Note:
     ///     [WMATA Station Information Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3310)
@@ -445,7 +477,10 @@ public extension MetroRail {
     }
 
     /// Parking information for this station
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateStationsParking)
     ///
     /// - Note:
     ///     [WMATA Station Parking Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330d)
@@ -470,7 +505,10 @@ public extension MetroRail {
     }
 
     /// Returns a set of ordered stations and distances between two stations _on the same line_
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegatePathBetweenStations)
     ///
     /// - Note:
     ///     [WMATA Path Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330e)
@@ -497,7 +535,10 @@ public extension MetroRail {
     }
 
     /// Opening and scheduled first and last trains for this station
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateStationTimings)
     ///
     /// - Note:
     ///     [WMATA Timings Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3312)
@@ -648,7 +689,10 @@ extension MetroRail: NeedsLine {}
 
 public extension MetroRail {
     /// Stations along a Line
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateStations)
     ///
     /// - Note:
     ///     [WMATA Stations Documentation]( https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3311)
@@ -710,7 +754,10 @@ public extension MetroRail {
     }
 
     /// GTFS RT 2.0 service alerts feed for WMATA rail.
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateAlerts)
     ///
     /// - Note:
     ///     [Google Alerts Documentation](https://developers.google.com/transit/gtfs-realtime/guides/service-alerts)
@@ -744,7 +791,10 @@ public extension MetroRail {
     }
 
     /// GTFS RT 2.0 trip updates feed for WMATA rail.
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateTripUpdates)
     ///
     /// - Note:
     ///     [Google Trip Updates Documentation](https://developers.google.com/transit/gtfs-realtime/guides/trip-updates)
@@ -775,7 +825,10 @@ public extension MetroRail {
     }
 
     /// GTFS RT 2.0 vehicle positions feed for WMATA rail.
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// [Corresponding WMATADelegate Handler](x-source-tag://DelegateVehiclePositions)
     ///
     /// - Note:
     ///     [Google Vehicle Positions Documentation]( https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions)

--- a/Sources/WMATA/MetroRail.swift
+++ b/Sources/WMATA/MetroRail.swift
@@ -33,8 +33,8 @@ public struct MetroRail: Fetcher {
     ///
     /// - Parameters:
     ///     - key: Your WMATA API key
-    ///     - delegate: The delegate to use for all delegate calls
-    ///     - sharedContainerIdentifier: Identifier for use with app extensions
+    ///     - delegate: The delegate to use for all delegate calls. Optional.
+    ///     - sharedContainerIdentifier: Identifier for use with app extensions. Optional.
     public init(key: String, delegate: WMATADelegate? = nil, sharedContainerIdentifier: String? = nil) {
         self.key = key
 
@@ -53,8 +53,12 @@ public struct MetroRail: Fetcher {
 
 // These don't require a Station or Line
 public extension MetroRail {
-    /// General information on all MetroRail lines
+    /// General information on all MetroRail lines.
+    ///
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// - Note:
+    ///     [WMATA Lines API Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330c)
     func lines() {
         request(
             request: URLRequest(url: RailURL.lines.rawValue, key: key),
@@ -63,6 +67,9 @@ public extension MetroRail {
     }
 
     /// General information on all MetroRail lines
+    ///
+    /// - Note:
+    ///     [WMATA Lines Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330c)
     ///
     /// - Parameters:
     ///     - completion: A completion handler
@@ -78,8 +85,11 @@ public extension MetroRail {
     /// Station entrances within a radius of a lat long pair, omit all parameters to receive all entrances
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Entrances Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330f)
+    ///
     /// - Parameters:
-    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at. Optional.
     func entrances(at radiusAtCoordinates: RadiusAtCoordinates? = nil) {
         var queryItems = [(String, String)]()
 
@@ -95,8 +105,11 @@ public extension MetroRail {
 
     /// Station entrances within a radius of a lat long pair, omit all parameters to receive all entrances
     ///
+    /// - Note:
+    ///     [WMATA Entrances Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330f)
+    ///
     /// - Parameters:
-    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at. Optional.
     ///     - completion: A completion handler
     ///     - result: [StationEntrances](x-source-tag://StationEntrances) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
     func entrances(at radiusAtCoordinates: RadiusAtCoordinates? = nil, completion: @escaping (_ result: Result<StationEntrances, WMATAError>) -> Void) {
@@ -115,6 +128,9 @@ public extension MetroRail {
 
     /// Uniquely identifiable trains in service and what track circuits they currently occupy
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// - Note:
+    ///     [WMATA Positions Documentation](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/5763fb35f91823096cac1058)
     func positions() {
         request(
             request: URLRequest(url: RailURL.positions.rawValue, key: key, queryItems: [("contentType", "json")]),
@@ -123,6 +139,9 @@ public extension MetroRail {
     }
 
     /// Uniquely identifiable trains in service and what track circuits they currently occupy
+    ///
+    /// - Note:
+    ///     [WMATA Positions Documentation](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/5763fb35f91823096cac1058)
     ///
     /// - Parameters:
     ///     - completion: A completion handler
@@ -137,6 +156,9 @@ public extension MetroRail {
 
     /// Ordered list of track circuits, arranged by line and track number
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// - Note:
+    ///     [WMATA Routes Documentation](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/57641afc031f59363c586dca)
     func routes() {
         request(
             request: URLRequest(url: RailURL.routes.rawValue, key: key, queryItems: [("contentType", "json")]),
@@ -145,6 +167,9 @@ public extension MetroRail {
     }
 
     /// Ordered list of track circuits, arranged by line and track number
+    ///
+    /// - Note:
+    ///     [WMATA Routes Documentation](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/57641afc031f59363c586dca)
     ///
     /// - Parameters:
     ///     - completion: A completion handler
@@ -159,6 +184,9 @@ public extension MetroRail {
 
     /// List of all track circuits - See https://developer.wmata.com/TrainPositionsFAQ
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// - Note:
+    ///     [WMATA Circuits Documentation](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/57644238031f59363c586dcb)
     func circuits() {
         request(
             request: URLRequest(url: RailURL.circuits.rawValue, key: key, queryItems: [("contentType", "json")]),
@@ -167,6 +195,9 @@ public extension MetroRail {
     }
 
     /// List of all track circuits - See https://developer.wmata.com/TrainPositionsFAQ
+    ///
+    /// - Note:
+    ///     [WMATA Circuits Documentation](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/57644238031f59363c586dcb)
     ///
     /// - Parameters:
     ///     - completion: A completion handler
@@ -185,6 +216,9 @@ public extension MetroRail {
 public extension MetroRail {
     /// General information on all MetroRail lines
     ///
+    /// - Note:
+    ///     [WMATA Lines Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330c)
+    ///
     /// - Returns: A Combine Publisher for [LinesResponse](x-source-tag://LinesResponse)
     func linesPublisher() -> AnyPublisher<LinesResponse, WMATAError> {
         publisher(
@@ -195,8 +229,11 @@ public extension MetroRail {
 
     /// Station entrances within a radius of a lat long pair, omit all parameters to receive all entrances
     ///
+    /// - Note:
+    ///     [WMATA Entrances Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330f)
+    ///
     /// - Parameters:
-    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at
+    ///     - radiusAtCoordinates: Radius at latitude and longitude to search at. Optional.
     ///
     /// - Returns: A Combine Publisher for [StationEntrances](x-source-tag://StationEntrances)
     func entrancesPublisher(at radiusAtCoordinates: RadiusAtCoordinates? = nil) -> AnyPublisher<StationEntrances, WMATAError> {
@@ -214,6 +251,9 @@ public extension MetroRail {
 
     /// Uniquely identifiable trains in service and what track circuits they currently occupy
     ///
+    /// - Note:
+    ///     [WMATA Positions Documentation](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/5763fb35f91823096cac1058)
+    ///
     /// - Returns: A Combine Publisher for [TrainPositions](x-source-tag://TrainPositions)
     func positionsPublisher() -> AnyPublisher<TrainPositions, WMATAError> {
         publisher(
@@ -224,6 +264,9 @@ public extension MetroRail {
 
     /// Ordered list of track circuits, arranged by line and track number
     ///
+    /// - Note:
+    ///     [WMATA Routes Documentation](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/57641afc031f59363c586dca)
+    ///
     /// - Returns: A Combine Publisher for [StandardRoutes](x-source-tag://StandardRoutes)
     func routesPublisher() -> AnyPublisher<StandardRoutes, WMATAError> {
         publisher(
@@ -233,6 +276,9 @@ public extension MetroRail {
     }
 
     /// List of all track circuits - See https://developer.wmata.com/TrainPositionsFAQ
+    ///
+    /// - Note:
+    ///     [WMATA Circuits Documentation](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/57644238031f59363c586dcb)
     ///
     /// - Returns: A Combine Publisher for [TrackCircuits](x-source-tag://TrackCircuits)
     func circuitsPublisher() -> AnyPublisher<TrackCircuits, WMATAError> {
@@ -249,18 +295,24 @@ public extension MetroRail {
     /// Distance, fare information, and estimated travel time between any two stations. Omit both station codes to receive information for all possible trips.
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Station To Station Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3313)
+    ///
     /// - Parameters:
-    ///     - station: Station to start trip at
-    ///     - destinationStation: Station to travel to
+    ///     - station: Station to start trip at. Optional.
+    ///     - destinationStation: Station to travel to. Optional.
     func station(_ station: Station? = nil, to destinationStation: Station? = nil) {
         (self as NeedsStation).station(station, to: destinationStation, key: key, session: urlSession)
     }
 
     /// Distance, fare information, and estimated travel time between any two stations. Omit both station codes to receive information for all possible trips.
     ///
+    /// - Note:
+    ///     [WMATA Station To Station Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3313)
+    ///
     /// - Parameters:
-    ///     - station: Station to start trip at
-    ///     - destinationStation: Station to travel to
+    ///     - station: Station to start trip at. Optional.
+    ///     - destinationStation: Station to travel to. Optional.
     ///     - completion: A completion handler
     ///     - result: [StationToStationInfos](x-source-tag://StationToStationInfos) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
     func station(_ station: Station? = nil, to destinationStation: Station? = nil, completion: @escaping (_ result: Result<StationToStationInfos, WMATAError>) -> Void) {
@@ -270,6 +322,9 @@ public extension MetroRail {
     /// Reported elevator and escalator incidents
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Elevator and Escalator Incidents Documentation](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d76)
+    ///
     /// - Parameters:
     ///     - station: Which station to search for incidents at. Optional.
     func elevatorAndEscalatorIncidents(at station: Station? = nil) {
@@ -277,6 +332,9 @@ public extension MetroRail {
     }
 
     /// Reported elevator and escalator incidents
+    ///
+    /// - Note:
+    ///     [WMATA Elevator and Escalator Incidents Documentation](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d76)
     ///
     /// - Parameters:
     ///     - station: Which station to search for incidents at. Optional.
@@ -289,6 +347,9 @@ public extension MetroRail {
     /// Reported MetroRail incidents
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Rail Incidents Documentation](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d77)
+    ///
     /// - Parameters:
     ///     - station: Station to search for incidents at. Optional.
     func incidents(at station: Station? = nil) {
@@ -296,6 +357,9 @@ public extension MetroRail {
     }
 
     /// Reported MetroRail incidents
+    ///
+    /// - Note:
+    ///     [WMATA Rail Incidents Documentation](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d77)
     ///
     /// - Parameters:
     ///     - station: Station to search for incidents at. Optional.
@@ -308,6 +372,9 @@ public extension MetroRail {
     /// Next train arrival information for this station
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Next Trains Documentation](https://developer.wmata.com/docs/services/547636a6f9182302184cda78/operations/547636a6f918230da855363f)
+    ///
     /// - Parameters:
     ///     - station: Station to search for trains at
     func nextTrains(at station: Station) {
@@ -315,6 +382,9 @@ public extension MetroRail {
     }
 
     /// Next train arrival information for this station
+    ///
+    /// - Note:
+    ///     [WMATA Next Trains Documentation](https://developer.wmata.com/docs/services/547636a6f9182302184cda78/operations/547636a6f918230da855363f)
     ///
     /// - Parameters:
     ///     - station: `Station` to search for trains at
@@ -327,6 +397,9 @@ public extension MetroRail {
     /// Next train arrival information for the given stations
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Next Trains Documentation](https://developer.wmata.com/docs/services/547636a6f9182302184cda78/operations/547636a6f918230da855363f)
+    ///
     /// - Parameters:
     ///     - stations: Stations to look up next trains for
     func nextTrains(at stations: [Station]) {
@@ -334,6 +407,9 @@ public extension MetroRail {
     }
 
     /// Next train arrival information for the given stations
+    ///
+    /// - Note:
+    ///     [WMATA Next Trains Documentation](https://developer.wmata.com/docs/services/547636a6f9182302184cda78/operations/547636a6f918230da855363f)
     ///
     /// - Parameters:
     ///     - stations: Stations to look up next trains for
@@ -346,6 +422,9 @@ public extension MetroRail {
     /// Location and address information for this station
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Station Information Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3310)
+    ///
     /// - Parameters:
     ///     - station: Station to search for information on
     func information(for station: Station) {
@@ -353,6 +432,9 @@ public extension MetroRail {
     }
 
     /// Location and address information for this station
+    ///
+    /// - Note:
+    ///     [WMATA Station Information Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3310)
     ///
     /// - Parameters:
     ///     - station: Station to search for information on
@@ -365,6 +447,9 @@ public extension MetroRail {
     /// Parking information for this station
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Station Parking Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330d)
+    ///
     /// - Parameters:
     ///     - station: Station to search for parking information on
     func parkingInformation(for station: Station) {
@@ -372,6 +457,9 @@ public extension MetroRail {
     }
 
     /// Parking information for this station
+    ///
+    /// - Note:
+    ///     [WMATA Station Parking Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330d)
     ///
     /// - Parameters:
     ///     - station: Station  to search for parking information on
@@ -384,6 +472,9 @@ public extension MetroRail {
     /// Returns a set of ordered stations and distances between two stations _on the same line_
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Path Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330e)
+    ///
     /// - Parameters:
     ///     - startingStation: Starting station to pathfind from
     ///     - destinationStation: Destination station to pathfind to
@@ -392,6 +483,9 @@ public extension MetroRail {
     }
 
     /// Returns a set of ordered stations and distances between two stations _on the same line_
+    ///
+    /// - Note:
+    ///     [WMATA Path Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330e)
     ///
     /// - Parameters:
     ///     - startingStation: Starting station to pathfind from
@@ -405,6 +499,9 @@ public extension MetroRail {
     /// Opening and scheduled first and last trains for this station
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Timings Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3312)
+    ///
     /// - Parameters:
     ///     - station: Station to search for timings on
     func timings(for station: Station) {
@@ -412,6 +509,9 @@ public extension MetroRail {
     }
 
     /// Opening and scheduled first and last trains for this station
+    ///
+    /// - Note:
+    ///     [WMATA Timings Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3312)
     ///
     /// - Parameters:
     ///     - station: Station to search for timings on
@@ -426,9 +526,12 @@ public extension MetroRail {
 public extension MetroRail {
     /// Distance, fare information, and estimated travel time between any two stations. Omit both station codes to receive information for all possible trips.
     ///
+    /// - Note:
+    ///     [WMATA Station To Station Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3313)
+    ///
     /// - Parameters:
-    ///     - station: Station to start trip at
-    ///     - destinationStation: Station to travel to
+    ///     - station: Station to start trip at. Optional.
+    ///     - destinationStation: Station to travel to. Optional.
     ///
     /// - Returns: A Combine Publisher for [StationToStationInfos](x-source-tag://StationToStationInfos)
     func stationPublisher(_ station: Station? = nil, to destinationStation: Station? = nil) -> AnyPublisher<StationToStationInfos, WMATAError> {
@@ -436,6 +539,9 @@ public extension MetroRail {
     }
 
     /// Reported elevator and escalator incidents
+    ///
+    /// - Note:
+    ///     [WMATA Elevator to Escalator Incidents Documentation](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d76)
     ///
     /// - Parameters:
     ///     - station: Which station to search for incidents at. Optional.
@@ -447,6 +553,9 @@ public extension MetroRail {
 
     /// Reported MetroRail incidents
     ///
+    /// - Note:
+    ///     [WMATA Rail Incidents Documentation](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d77)
+    ///
     /// - Parameters:
     ///     - station: Station to search for incidents at. Optional.
     ///
@@ -456,6 +565,9 @@ public extension MetroRail {
     }
 
     /// Next train arrival information for this station
+    ///
+    /// - Note:
+    ///     [WMATA Next Trains Documentation](https://developer.wmata.com/docs/services/547636a6f9182302184cda78/operations/547636a6f918230da855363f)
     ///
     /// - Parameters:
     ///     - station: Station to search for trains at
@@ -467,6 +579,9 @@ public extension MetroRail {
 
     /// Next train arrival information for the given stations
     ///
+    /// - Note:
+    ///     [WMATA Next Trains Documentation](https://developer.wmata.com/docs/services/547636a6f9182302184cda78/operations/547636a6f918230da855363f)
+    ///
     /// - Parameters:
     ///     - stations: Stations to look up next trains for
     ///
@@ -476,6 +591,9 @@ public extension MetroRail {
     }
 
     /// Location and address information for this station
+    ///
+    /// - Note:
+    ///     [WMATA Station Information Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3310)
     ///
     /// - Parameters:
     ///     - station: Station search for information on
@@ -487,6 +605,9 @@ public extension MetroRail {
 
     /// Parking information for this station
     ///
+    /// - Note:
+    ///     [WMATA Station Parking Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330d)
+    ///
     /// - Parameters:
     ///     - station: Station to search for parking information on
     ///
@@ -496,6 +617,9 @@ public extension MetroRail {
     }
 
     /// Returns a set of ordered stations and distances between two stations _on the same line_
+    ///
+    /// - Note:
+    ///     [WMATA Path Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330e)
     ///
     /// - Parameters:
     ///     - startingStation: Starting station to pathfind from
@@ -507,6 +631,9 @@ public extension MetroRail {
     }
 
     /// Opening and scheduled first and last trains for this station
+    ///
+    /// - Note:
+    ///     [WMATA Timings Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3312)
     ///
     /// - Parameters:
     ///     - station: Station to search for timings for
@@ -523,6 +650,9 @@ public extension MetroRail {
     /// Stations along a Line
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
     ///
+    /// - Note:
+    ///     [WMATA Stations Documentation]( https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3311)
+    ///
     /// - Parameters:
     ///     - line: Line to receive stations along. Omit to receive all stations.
     func stations(for line: Line? = nil) {
@@ -530,6 +660,9 @@ public extension MetroRail {
     }
 
     /// Stations along a Line
+    ///
+    /// - Note:
+    ///     [WMATA Stations Documentation]( https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3311)
     ///
     /// - Parameters:
     ///     - line: Line to receive stations along. Omit to receive all stations.
@@ -544,9 +677,13 @@ public extension MetroRail {
 public extension MetroRail {
     /// Stations along a Line
     ///
+    /// - Note:
+    ///     [WMATA Stations Documentation]( https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3311)
+    ///
     /// - Parameters:
     ///     - line: Line to receive stations along. Omit to receive all stations.
-    /// - returns: A Combine Publisher for [Stations](x-source-tag://Stations)
+    ///
+    /// - Returns: A Combine Publisher for [Stations](x-source-tag://Stations)
     func stationsPublisher(for line: Line? = nil) -> AnyPublisher<Stations, WMATAError> {
         (self as NeedsLine).stationsPublisher(for: line, key: key, session: urlSession)
     }
@@ -557,7 +694,9 @@ extension MetroRail: GTFSRTFetcher {}
 /// GTFS-RT Calls
 public extension MetroRail {
     /// GTFS RT 2.0 service alerts feed for WMATA rail.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/service-alerts
+    ///
+    /// - Note:
+    ///     [Google Alerts Documentation](https://developers.google.com/transit/gtfs-realtime/guides/service-alerts)
     ///
     /// - Parameters:
     ///     - completion: A completion handler
@@ -571,8 +710,10 @@ public extension MetroRail {
     }
 
     /// GTFS RT 2.0 service alerts feed for WMATA rail.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/service-alerts
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// - Note:
+    ///     [Google Alerts Documentation](https://developers.google.com/transit/gtfs-realtime/guides/service-alerts)
     func alerts() {
         request(
             request: URLRequest(
@@ -584,7 +725,9 @@ public extension MetroRail {
     }
 
     /// GTFS RT 2.0 trip updates feed for WMATA rail.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/trip-updates
+    ///
+    /// - Note:
+    ///     [Google Trip Updates Documentation](https://developers.google.com/transit/gtfs-realtime/guides/trip-updates)
     ///
     /// - Parameters:
     ///     - completion: A completion handler
@@ -601,8 +744,10 @@ public extension MetroRail {
     }
 
     /// GTFS RT 2.0 trip updates feed for WMATA rail.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/trip-updates
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// - Note:
+    ///     [Google Trip Updates Documentation](https://developers.google.com/transit/gtfs-realtime/guides/trip-updates)
     func tripUpdates() {
         request(
             request: URLRequest(
@@ -614,7 +759,9 @@ public extension MetroRail {
     }
 
     /// GTFS RT 2.0 vehicle positions feed for WMATA rail.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions
+    ///
+    /// - Note:
+    ///     [Google Vehicle Positions Documentation]( https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions)
     ///
     /// - Parameters:
     ///     - completion: A completion handler
@@ -628,8 +775,10 @@ public extension MetroRail {
     }
 
     /// GTFS RT 2.0 vehicle positions feed for WMATA rail.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions
     /// For use with a [WMATADelegate](x-source-tag://WMATADelegate)
+    ///
+    /// - Note:
+    ///     [Google Vehicle Positions Documentation]( https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions)
     func vehiclePositions() {
         request(
             request: URLRequest(
@@ -644,7 +793,9 @@ public extension MetroRail {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public extension MetroRail {
     /// GTFS RT 2.0 service alerts feed for WMATA rail.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/service-alerts
+    ///
+    /// - Note:
+    ///     [Google Alerts Documentation](https://developers.google.com/transit/gtfs-realtime/guides/service-alerts)
     ///
     /// - Returns: A Combine Publisher for `TransitRealtime_FeedMessage`
     func alertsPublisher() -> AnyPublisher<TransitRealtime_FeedMessage, WMATAError> {
@@ -655,7 +806,9 @@ public extension MetroRail {
     }
 
     /// GTFS RT 2.0 trip updates feed for WMATA rail.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/trip-updates
+    ///
+    /// - Note:
+    ///     [WMATA Trip Updates Documentation](https://developers.google.com/transit/gtfs-realtime/guides/trip-updates)
     ///
     /// - Returns: A Combine Publisher for `TransitRealtime_FeedMessage`
     func tripUpdatesPublisher() -> AnyPublisher<TransitRealtime_FeedMessage, WMATAError> {
@@ -669,7 +822,9 @@ public extension MetroRail {
     }
 
     /// GTFS RT 2.0 vehicle positions feed for WMATA rail.
-    /// See https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions
+    ///
+    /// - Note:
+    ///     [WMATA Vehicle Positions Documentation](https://developers.google.com/transit/gtfs-realtime/guides/vehicle-positions)
     ///
     /// - Returns: A Combine Publisher for`TransitRealtime_FeedMessage`
     func vehiclePositionsPublisher() -> AnyPublisher<TransitRealtime_FeedMessage, WMATAError> {

--- a/Sources/WMATA/Rail/Lines.swift
+++ b/Sources/WMATA/Rail/Lines.swift
@@ -24,6 +24,9 @@ extension Line: NeedsLine {}
 public extension Line {
     /// Stations along this Line
     ///
+    /// - Note:
+    ///     [WMATA Stations Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3311)
+    ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request
     ///     - session: Optional. URL Session to make this request with
@@ -37,6 +40,9 @@ public extension Line {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public extension Line {
     /// Stations along this Line
+    ///
+    /// - Note:
+    ///     [WMATA Stations Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3311)
     ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request

--- a/Sources/WMATA/Rail/Lines.swift
+++ b/Sources/WMATA/Rail/Lines.swift
@@ -23,10 +23,13 @@ extension Line: NeedsLine {}
 
 public extension Line {
     /// Stations along this Line
-    /// - Parameter apiKey: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - Parameter completion: completion handler that returns `Stations`
-    func stations(key: String, session: URLSession = URLSession.shared, completion: @escaping (Result<Stations, WMATAError>) -> Void) {
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///     - completion: A completion handler
+    ///     - result: [Stations](x-source-tag://Stations) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func stations(key: String, session: URLSession = URLSession.shared, completion: @escaping (_ result: Result<Stations, WMATAError>) -> Void) {
         (self as NeedsLine).stations(for: self, key: key, session: session, completion: completion)
     }
 }
@@ -34,9 +37,12 @@ public extension Line {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public extension Line {
     /// Stations along this Line
-    /// - Parameter apiKey: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - returns: A Combine Publisher for `Stations`
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///
+    /// - Returns: A Combine Publisher for [Stations](x-source-tag://Stations)
     func stationsPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<Stations, WMATAError> {
         (self as NeedsLine).stationsPublisher(for: self, key: key, session: session)
     }

--- a/Sources/WMATA/Rail/RailResponses.swift
+++ b/Sources/WMATA/Rail/RailResponses.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// Container for [RailPrediction](x-source-tag://railPrediction)s
 public struct RailPredictions: Codable {
     public let trains: [RailPrediction]
 
@@ -19,6 +20,7 @@ public struct RailPredictions: Codable {
     }
 }
 
+/// - Tag: railPrediction
 public struct RailPrediction: Codable {
     public let car: String?
     public let destination: String

--- a/Sources/WMATA/Rail/RailResponses.swift
+++ b/Sources/WMATA/Rail/RailResponses.swift
@@ -7,29 +7,53 @@
 
 import Foundation
 
-/// Container for [RailPrediction](x-source-tag://railPrediction)s
+/// Response from the [Next Trains API](https://developer.wmata.com/docs/services/547636a6f9182302184cda78/operations/547636a6f918230da855363f)
+/// - Tag: RailPredictions
 public struct RailPredictions: Codable {
+    /// List of predictions
     public let trains: [RailPrediction]
 
     enum CodingKeys: String, CodingKey {
         case trains = "Trains"
     }
 
+    /// Create a rail predictions response
+    ///
+    /// - Parameters:
+    ///     - trains: List of rail predictions
     public init(trains: [RailPrediction]) {
         self.trains = trains
     }
 }
 
-/// - Tag: railPrediction
+/// Response from the [Next Trains API](https://developer.wmata.com/docs/services/547636a6f9182302184cda78/operations/547636a6f918230da855363f)
+/// - Tag: RailPrediction
 public struct RailPrediction: Codable {
+    /// Number of cars on a train, usually 6 or 8, but might also return -.
     public let car: String?
+    
+    /// Abbreviated version of the final destination for a train. This is similar to what is displayed on the signs at stations.
     public let destination: String
+    
+    /// Destination station
     public let destinationCode: Station?
+    
+    /// When DestinationCode is populated, this is the full name of the destination station, as shown on the WMATA website.
     public let destinationName: String
+    
+    /// Denotes the track this train is on, but does not necessarily equate to Track 1 or Track 2. With the exception of terminal stations, predictions at the same station with different Group values refer to trains on different tracks.
     public let group: String
+    
+    /// Line of the train
     public let line: Line
+    
+    /// The station the train is currently arriving at
     public let location: Station
+    
+    /// Full name of the station where the train is arriving.
     public let locationName: String
+    
+    /// Minutes until arrival. Can be a numeric value, ARR (arriving), BRD (boarding), ---, or empty.
     public let minutes: String
 
     enum CodingKeys: String, CodingKey {
@@ -44,6 +68,18 @@ public struct RailPrediction: Codable {
         case minutes = "Min"
     }
 
+    /// Create a rail prediction response
+    ///
+    /// - Parameters:
+    ///     - car: Number of train cars
+    ///     - destination: Abbreviated version of destination
+    ///     - destinationCode: Destination station
+    ///     - destinationName: Full name of destination
+    ///     - group: Track the train is on
+    ///     - line: Line of train
+    ///     - location: Station the train is currently arriving at
+    ///     - locationName: Full name of station the train is currently arriving at
+    ///     - minutes: Minutes until arrival
     public init(
         car: String?,
         destination: String,
@@ -118,27 +154,53 @@ public struct RailPrediction: Codable {
     }
 }
 
+/// Response from the [Live Train Positions API](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/5763fb35f91823096cac1058)
+/// - Tag: TrainPositions
 public struct TrainPositions: Codable {
+    /// List of train positions
     public let trainPositions: [TrainPosition]
 
     enum CodingKeys: String, CodingKey {
         case trainPositions = "TrainPositions"
     }
 
+    /// Create a train positions response
+    ///
+    /// - Parameters:
+    ///     - trainPositions: List of train positions
     public init(trainPositions: [TrainPosition]) {
         self.trainPositions = trainPositions
     }
 }
 
+/// Response from the [Live Train Positions API](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/5763fb35f91823096cac1058)
+/// - Tag: TrainPosition
 public struct TrainPosition: Codable {
+    /// Uniquely identifiable internal train identifier
     public let trainId: String
+    
+    /// Non-unique train identifier, often used by WMATA's Rail Scheduling and Operations Teams, as well as over open radio communication.
     public let trainNumber: String
+    
+    /// Number of cars. Can be 0.
     public let carCount: Int
+    
+    /// The direction of movement regardless of which track the train is on.
     public let directionNumber: Int
+    
+    /// The circuit identifier the train is currently on.
     public let circuitId: Int
+    
+    /// Destination of train
     public let destination: Station?
+    
+    /// Line the train is on
     public let line: Line?
+    
+    /// Approximate "dwell time". This is not an exact value, but can be used to determine how long a train has been reported at the same track circuit.
     public let secondsAtLocation: Int
+    
+    /// Service Type of a train.
     public let serviceType: String
 
     enum CodingKeys: String, CodingKey {
@@ -153,6 +215,18 @@ public struct TrainPosition: Codable {
         case serviceType = "ServiceType"
     }
 
+    /// Create a train position response
+    ///
+    /// - Parameters:
+    ///     - trainId: Unique train identifier
+    ///     - trainNumber: Non-unique train identifier
+    ///     - carCount: Number of cars on train
+    ///     - directionNumber: Direction of movement
+    ///     - circuitId: Circuit identifier train is currently on
+    ///     - destination: Destination of train
+    ///     - line: Line the train is currently on
+    ///     - secondsAtLocation: Dwell time
+    ///     - serviceType: Type of service of train
     public init(
         trainId: String,
         trainNumber: String,
@@ -229,21 +303,35 @@ public struct TrainPosition: Codable {
     }
 }
 
+/// Response from the [Standard Routes API](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/57641afc031f59363c586dca)
+/// - Tag: StandardRoutes
 public struct StandardRoutes: Codable {
+    /// List of standard routes
     public let standardRoutes: [StandardRoute]
 
     enum CodingKeys: String, CodingKey {
         case standardRoutes = "StandardRoutes"
     }
 
+    /// Create a standard routes response
+    ///
+    /// - Parameters:
+    ///     - standardRoutes: List of standard routes
     public init(standardRoutes: [StandardRoute]) {
         self.standardRoutes = standardRoutes
     }
 }
 
+/// Response from the [Standard Routes API](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/57641afc031f59363c586dca)
+/// - Tag: StandardRoute
 public struct StandardRoute: Codable {
+    /// Line of this route
     public let line: Line
+    
+    /// Track number. 1 or 2.
     public let trackNumber: Int
+    
+    /// Array containing ordered track circuit information
     public let trackCircuits: [TrackCircuitWithStation]
 
     enum CodingKeys: String, CodingKey {
@@ -252,6 +340,12 @@ public struct StandardRoute: Codable {
         case trackCircuits = "TrackCircuits"
     }
 
+    /// Create a standard route response
+    ///
+    /// - Parameters:
+    ///     - line: Line of route
+    ///     - trackNumber: Track the route is on
+    ///     - trackCiruits: Ordered track circuit information
     public init(
         line: Line,
         trackNumber: Int,
@@ -286,9 +380,16 @@ public struct StandardRoute: Codable {
     }
 }
 
+/// Response from the [Standard Routes API](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/57641afc031f59363c586dca)
+/// - Tag: TrackCircuitWithStation
 public struct TrackCircuitWithStation: Codable {
+    /// Order in which the circuit appears for the given line and track.
     public let sequenceNumber: Int
+    
+    /// An internal system-wide uniquely identifiable circuit number.
     public let circuitId: Int
+    
+    /// Station this circuit is at, if it is at a station
     public let station: Station?
 
     enum CodingKeys: String, CodingKey {
@@ -297,6 +398,12 @@ public struct TrackCircuitWithStation: Codable {
         case station = "StationCode"
     }
 
+    /// Create a track circuit with station response
+    ///
+    /// - Parameters:
+    ///     - sequenceNumber: Order the ciruit appears in
+    ///     - circuitId: Unique circuit id
+    ///     - station: Station the circuit is at, if it's at one
     public init(
         sequenceNumber: Int,
         circuitId: Int,
@@ -336,21 +443,35 @@ public struct TrackCircuitWithStation: Codable {
     }
 }
 
+/// Response from the [Track Circuits API](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/57644238031f59363c586dcb)
+/// - Tag: TrackCircuits
 public struct TrackCircuits: Codable {
+    /// List of track ciruits
     public let trackCircuits: [TrackCircuit]
 
     enum CodingKeys: String, CodingKey {
         case trackCircuits = "TrackCircuits"
     }
 
+    /// Create a track circuits response
+    ///
+    /// - Parameters:
+    ///     - trackCircuits: List of track circuits
     public init(trackCircuits: [TrackCircuit]) {
         self.trackCircuits = trackCircuits
     }
 }
 
+/// Response from the [Track Circuits API](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/57644238031f59363c586dcb)
+/// - Tag: TrackCircuit
 public struct TrackCircuit: Codable {
+    /// Track number. 1 and 2 denote "main" lines, while 0 and 3 are connectors (between different types of tracks) and pocket tracks, respectively.
     public let track: Int
+    
+    /// An internal system-wide uniquely identifiable circuit number.
     public let circuitId: Int
+    
+    /// Array containing track circuit neighbor information. Note that some track circuits have no neighbors in one direction. All track circuits have at least one neighbor.
     public let neighbors: [TrackNeighbor]
 
     enum CodingKeys: String, CodingKey {
@@ -359,6 +480,12 @@ public struct TrackCircuit: Codable {
         case neighbors = "Neighbors"
     }
 
+    /// Create a track circuit response
+    ///
+    /// - Parameters:
+    ///     - track: Track number
+    ///     - circuitId: Unique circuit id
+    ///     - neighbors: Track circuit neighbors
     public init(
         track: Int,
         circuitId: Int,
@@ -370,8 +497,13 @@ public struct TrackCircuit: Codable {
     }
 }
 
+/// Response from the [Track Circuits API](https://developer.wmata.com/docs/services/5763fa6ff91823096cac1057/operations/57644238031f59363c586dcb)
+/// - Tag: TrackNeighbor
 public struct TrackNeighbor: Codable {
+    /// Left or Right neighbor group. Generally speaking, left neighbors are to the west and south, while right neighbors are to the east/north.
     public let neighborType: String
+    
+    /// Neighboring circuit ids.
     public let circuitIds: [Int]
 
     enum CodingKeys: String, CodingKey {
@@ -379,6 +511,11 @@ public struct TrackNeighbor: Codable {
         case circuitIds = "CircuitIds"
     }
 
+    /// Create a track neighbor response
+    ///
+    /// - Parameters:
+    ///     - neighborType: Left or Right neighbor group
+    ///     - circuitIds: Neighboring circuits
     public init(
         neighborType: String,
         circuitIds: [Int]
@@ -388,24 +525,44 @@ public struct TrackNeighbor: Codable {
     }
 }
 
+/// Response from the [Lines API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330c)
+/// - Tag: LinesResponse
 public struct LinesResponse: Codable {
+    /// List of lines
     public let lines: [LineResponse]
 
     enum CodingKeys: String, CodingKey {
         case lines = "Lines"
     }
 
+    /// Create lines response
+    ///
+    /// - Parameters:
+    ///     - lines: List of lines
     public init(lines: [LineResponse]) {
         self.lines = lines
     }
 }
 
+/// Response from the [Lines API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330c)
+/// - Tag: LineResponse
 public struct LineResponse: Codable {
+    /// Line code
     public let line: Line
+    
+    /// Full name of the Line.
     public let displayName: String
+    
+    /// Station for start of the Line.
     public let startStation: Station
+    
+    /// Station for end of the Line
     public let endStation: Station
+    
+    /// Intermediate terminal station. During normal service, some trains on some lines might end their trip prior to the StartStationCode or EndStationCode. A good example is on the Red Line where some trains stop at A11 (Grosvenor) or B08 (Silver Spring).
     public let firstInternalDestination: Station?
+    
+    /// Intermediate terminal station. During normal service, some trains on some lines might end their trip prior to the StartStationCode or EndStationCode. A good example is on the Red Line where some trains stop at A11 (Grosvenor) or B08 (Silver Spring).
     public let secondInternalDestination: Station?
 
     enum CodingKeys: String, CodingKey {
@@ -417,6 +574,15 @@ public struct LineResponse: Codable {
         case secondInternalDestination = "InternalDestination2"
     }
 
+    /// Create a line response
+    ///
+    /// - Parameters:
+    ///     - line: Line code
+    ///     - displayName: Name of line
+    ///     - startStation: Station at start of Line
+    ///     - endStation: Station at end of Line
+    ///     - firstInternalDestination: Intermediate terminal station
+    ///     - secondInternalDestination: Intermediate terminal station
     public init(
         line: Line,
         displayName: String,
@@ -494,22 +660,38 @@ public struct LineResponse: Codable {
     }
 }
 
+/// Response from the [Parking Information API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330d)
+/// - Tag: StationsParking
 public struct StationsParking: Codable {
+    /// List of parking information
     public let stationsParking: [StationParking]
 
     enum CodingKeys: String, CodingKey {
         case stationsParking = "StationsParking"
     }
 
+    /// Create stations parking response
+    ///
+    /// - Parameters:
+    ///     - stationsParking: List of parking information
     public init(stationsParking: [StationParking]) {
         self.stationsParking = stationsParking
     }
 }
 
+/// Response from the [Parking Information API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330d)
+/// - Tag: StationParking
 public struct StationParking: Codable {
+    /// Station this parking info is for
     public let station: Station
+    
+    /// When not empty, provides additional parking resources such as nearby lots.
     public let notes: String
+    
+    /// All-day parking options.
     public let allDayParking: AllDayParking
+    
+    /// Short-term parking options.
     public let shortTermParking: ShortTermParking
 
     enum CodingKeys: String, CodingKey {
@@ -519,6 +701,13 @@ public struct StationParking: Codable {
         case shortTermParking = "ShortTermParking"
     }
 
+    /// Create a station parking response
+    ///
+    /// - Parameters:
+    ///     - station: Station for this parking info
+    ///     - notes: Additional parking information
+    ///     - allDayParking: All-day parking options
+    ///     - shortTermParking: Short term parking options
     public init(
         station: Station,
         notes: String,
@@ -556,11 +745,22 @@ public struct StationParking: Codable {
     }
 }
 
+/// Response from the [Parking Information API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330d)
+/// - Tag: AllDayParking
 public struct AllDayParking: Codable {
+    /// Number of all-day parking spots available at a station.
     public let totalCount: Int
+    
+    /// All-day cost per day (weekday) for Metro riders.
     public let riderCost: Double
+    
+    /// All-day cost per day (weekday) for non-Metro riders.
     public let nonRiderCost: Double
+    
+    /// Similar to RiderCost, except denoting Saturday prices.
     public let saturdayRiderCost: Double
+    
+    /// Similar to NonRiderCost, except denoting Saturday prices.
     public let saturdayNonRiderCost: Double
 
     enum CodingKeys: String, CodingKey {
@@ -571,6 +771,14 @@ public struct AllDayParking: Codable {
         case saturdayNonRiderCost = "SaturdayNonRiderCost"
     }
 
+    /// Create all day parking response
+    ///
+    /// - Parameters:
+    ///     - totalCount: Number of all day parking spots
+    ///     - riderCost: All day weekday costs for Metro riders
+    ///     - nonRiderCost: All day weekday cost for non-Metro riders
+    ///     - saturdayRiderCost: riderCost, but for Saturdays
+    ///     - saturdayNonRiderCost: nonRiderCost, but for Saturdays
     public init(
         totalCount: Int,
         riderCost: Double,
@@ -586,8 +794,13 @@ public struct AllDayParking: Codable {
     }
 }
 
+/// Response from the [Parking Information API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330d)
+/// - Tag: ShortTermParking
 public struct ShortTermParking: Codable {
+    /// Number of short-term parking spots available at a station (parking meters).
     public let totalCount: Int
+    
+    /// Misc. information relating to short-term parking.
     public let notes: String
 
     enum CodingKeys: String, CodingKey {
@@ -595,6 +808,11 @@ public struct ShortTermParking: Codable {
         case notes = "Notes"
     }
 
+    /// Create a short term parking response
+    ///
+    /// - Parameters:
+    ///     - totalCount: Number of parking meters available at this station
+    ///     - notes: Misc. parking information
     public init(
         totalCount: Int,
         notes: String
@@ -604,23 +822,41 @@ public struct ShortTermParking: Codable {
     }
 }
 
+/// Response from the [Path Between Stations API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330e)
+/// - Tag: PathBetweenStations
 public struct PathBetweenStations: Codable {
+    /// List of path information
     public let path: [Path]
 
     enum CodingKeys: String, CodingKey {
         case path = "Path"
     }
 
+    /// Create a path between stations response
+    ///
+    /// - Parameters:
+    ///     - path: List of path information
     public init(path: [Path]) {
         self.path = path
     }
 }
 
+/// Response from the [Path Between Stations API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330e)
+/// - Tag: Path
 public struct Path: Codable {
+    /// Distance in feet to the previous station in the list.
     public let distanceToPreviousStation: Int
+    
+    /// Line of this station
     public let line: Line
+    
+    /// Order this path appears
     public let sequenceNumber: Int
+    
+    /// Station code
     public let station: Station
+    
+    /// Full name for this station, as shown on the WMATA website.
     public let stationName: String
 
     enum CodingKeys: String, CodingKey {
@@ -631,6 +867,14 @@ public struct Path: Codable {
         case stationName = "StationName"
     }
 
+    /// Create a path response
+    ///
+    /// - Parameters:
+    ///     - distanceToPreviousStation: Distance in feet to previous station
+    ///     - line: Line of this station
+    ///     - sequenceNumber: Order this path appears
+    ///     - station: Station code
+    ///     - stationName: Full station name
     public init(
         distanceToPreviousStation: Int,
         line: Line,
@@ -681,25 +925,47 @@ public struct Path: Codable {
     }
 }
 
+/// Response from the [Station Entrances API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330f)
+/// - Tag: StationEntrances
 public struct StationEntrances: Codable {
+    /// List of station entrances
     public let entrances: [StationEntrance]
 
     enum CodingKeys: String, CodingKey {
         case entrances = "Entrances"
     }
 
+    /// Create a station entrances response
+    ///
+    /// - Parameters:
+    ///     - entrances: List of station entrances
     public init(entrances: [StationEntrance]) {
         self.entrances = entrances
     }
 }
 
+/// Response from the [Station Entrances API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330f)
+/// - Tag: StationEntrance
 public struct StationEntrance: Codable {
+    /// Additional information for the entrance.
     public let description: String
+    
+    /// Warning: Deprecated.
     public let id: String
+    
+    /// Latitude of entrance.
     public let latitude: Double
+    
+    /// Longitude of entrance.
     public let longitude: Double
+    
+    /// Name of entrance.
     public let name: String
+    
+    /// First station for this entrance
     public let firstStation: Station
+    
+    /// Second station for this entrance. See multilevel stations like L'Enfant Plaza, Metro Center
     public let secondStation: Station?
 
     enum CodingKeys: String, CodingKey {
@@ -712,6 +978,16 @@ public struct StationEntrance: Codable {
         case secondStation = "StationCode2"
     }
 
+    /// Create a station entrance response
+    ///
+    /// - Parameters:
+    ///     - description: Additional entrance information
+    ///     - id: Deprecated.
+    ///     - latitude: Latitude of entrance
+    ///     - longitude: Longitude of entrance
+    ///     - name: Name of entrance
+    ///     - firstStation: First station of this entrance
+    ///     - secondStation: Second station of this entrance. i.e. L'Enfant Plaza
     public init(
         description: String,
         id: String,
@@ -774,17 +1050,41 @@ public struct StationEntrance: Codable {
     }
 }
 
+/// Response from the [Station Information API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3310),
+/// Response from the [Station List API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3311)
+/// - Tag: StationInformation
 public struct StationInformation: Codable {
+    /// Address information.
     public let address: StationAddress
+    
+    /// Station code
     public let station: Station
+    
+    /// Latitude of this station.
     public let latitude: Double
+    
+    /// Longitude of this station.
     public let longitude: Double
+    
+    /// First line of this station
     public let firstLine: Line
+    
+    /// Second line of this station
     public let secondLine: Line?
+    
+    /// Third line of this station
     public let thirdLine: Line?
+    
+    /// Fourth line of this station. Unused.
     public let fourthLine: Line?
+    
+    /// Name of this station
     public let name: String
+    
+    /// For stations with multiple platforms (e.g.: Gallery Place, Fort Totten, L'Enfant Plaza, and Metro Center), the additional station will be listed here.
     public let firstStationTogether: Station?
+    
+    /// Unused.
     public let secondStationTogether: Station?
 
     enum CodingKeys: String, CodingKey {
@@ -801,6 +1101,20 @@ public struct StationInformation: Codable {
         case secondStationTogether = "StationTogether2"
     }
 
+    /// Create a station information response
+    ///
+    /// - Parameters:
+    ///     - address: Address information
+    ///     - station: Station code
+    ///     - latitude: Latitude of this station
+    ///     - longitude: Longitude of this station
+    ///     - firstLine: First line of this station
+    ///     - secondLine: Second line of this station
+    ///     - thirdLine: Third line of this station
+    ///     - fourthLine: Fourth line of this station. Unused.
+    ///     - name: Name of station
+    ///     - firstStationTogether: Additional station for multilevel stations like Fort Totten
+    ///     - secondStationTogether: Unused
     public init(
         address: StationAddress,
         station: Station,
@@ -935,10 +1249,19 @@ public struct StationInformation: Codable {
     }
 }
 
+/// Response from the [Station Information API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3310)
+/// - Tag: StationAddress
 public struct StationAddress: Codable {
+    /// City of this station.
     public let city: String
+    
+    /// State of this station.
     public let state: String
+    
+    /// Street address (for GPS use) of this station.
     public let street: String
+    
+    /// Zip code of this station.
     public let zip: String
 
     enum CodingKeys: String, CodingKey {
@@ -948,6 +1271,13 @@ public struct StationAddress: Codable {
         case zip = "Zip"
     }
 
+    /// Create station address response
+    ///
+    /// - Parameters:
+    ///     - city: City of this station
+    ///     - state: State of this station
+    ///     - street: Stress address of this station
+    ///     - zip: Zip code of this station
     public init(
         city: String,
         state: String,
@@ -961,39 +1291,72 @@ public struct StationAddress: Codable {
     }
 }
 
+/// Response from the [Station List API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3311)
+/// - Tag: Stations
 public struct Stations: Codable {
+    /// List of station information
     public let stations: [StationInformation]
 
     enum CodingKeys: String, CodingKey {
         case stations = "Stations"
     }
 
+    /// Create a stations response
+    ///
+    /// - Parameters:
+    ///     - stations: List of station information
     public init(stations: [StationInformation]) {
         self.stations = stations
     }
 }
 
+/// Response from the [Station Timings API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3312)
+/// - Tag: StationTimings
 public struct StationTimings: Codable {
+    /// List of station times
     public let stationTimes: [StationTime]
 
     enum CodingKeys: String, CodingKey {
         case stationTimes = "StationTimes"
     }
 
+    /// Create a station timings response
+    ///
+    /// - Parameters:
+    ///     - stationTimes: List of station times
     public init(stationTimes: [StationTime]) {
         self.stationTimes = stationTimes
     }
 }
 
+/// Response from the [Station Timings API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3312)
+/// - Tag: StationTime
 public struct StationTime: Codable {
+    /// Station code
     public let station: Station
+    
+    /// Full name of the station.
     public let stationName: String
+    
+    /// Timing information for Monday
     public let monday: StationFirstLastTrains
+    
+    /// Timing information for Tuesday
     public let tuesday: StationFirstLastTrains
+    
+    /// Timing information for Wednesday
     public let wednesday: StationFirstLastTrains
+    
+    /// Timing information for Thursday
     public let thursday: StationFirstLastTrains
+    
+    /// Timing information for Friday
     public let friday: StationFirstLastTrains
+    
+    /// Timing information for Saturday
     public let saturday: StationFirstLastTrains
+    
+    /// Timing information for Sunday
     public let sunday: StationFirstLastTrains
 
     enum CodingKeys: String, CodingKey {
@@ -1008,6 +1371,18 @@ public struct StationTime: Codable {
         case sunday = "Sunday"
     }
 
+    /// Create a station time response
+    ///
+    /// - Parameters:
+    ///     - station: Station code
+    ///     - stationName: Name of station
+    ///     - monday: Timing information for Monday
+    ///     - tuesday: Timing information for Tuesday
+    ///     - wednesday: Timing information for Wednesday
+    ///     - thursday: Timing information for Thursday
+    ///     - friday: Timing information for Friday
+    ///     - saturday: Timing information for Saturday
+    ///     - sunday: Timing information for Sunday
     public init(
         station: Station,
         stationName: String,
@@ -1065,9 +1440,16 @@ public struct StationTime: Codable {
     }
 }
 
+/// Response from the [Station Timings API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3312)
+/// - Tag: StationFirstLastTrains
 public struct StationFirstLastTrains: Codable {
+    /// Station opening time. Format is HH:mm.
     public let openingTime: String
+    
+    /// First train information
     public let firstTrains: [TrainTime]
+    
+    /// Last train information
     public let lastTrains: [TrainTime]
 
     enum CodingKeys: String, CodingKey {
@@ -1076,6 +1458,12 @@ public struct StationFirstLastTrains: Codable {
         case lastTrains = "LastTrains"
     }
 
+    /// Create a station first last trains response
+    ///
+    /// - Parameters:
+    ///     - openingTime: Station opening time
+    ///     - firstTrains: First train information
+    ///     - lastTrains: Last trains information
     public init(
         openingTime: String,
         firstTrains: [TrainTime],
@@ -1087,8 +1475,13 @@ public struct StationFirstLastTrains: Codable {
     }
 }
 
+/// Response from the [Station Timings API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3312)
+/// - Tag: TrainTime
 public struct TrainTime: Codable {
+    /// Time the train leaves the station. Format is HH:mm.
     public let time: String
+    
+    /// Train's destination
     public let destination: Station
 
     enum CodingKeys: String, CodingKey {
@@ -1096,6 +1489,11 @@ public struct TrainTime: Codable {
         case destination = "DestinationStation"
     }
 
+    /// Create a train time response
+    ///
+    /// - Parameters:
+    ///     - time: Time the train leaves the station
+    ///     - destination: Destination station
     public init(time: String, destination: Station) {
         self.time = time
         self.destination = destination
@@ -1123,23 +1521,41 @@ public struct TrainTime: Codable {
     }
 }
 
+/// Response from the [Station to Station Information API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3313)
+/// - Tag: StationToStationInfos
 public struct StationToStationInfos: Codable {
+    /// List of station to station info
     public let stationToStationInfos: [StationToStationInfo]
 
     enum CodingKeys: String, CodingKey {
         case stationToStationInfos = "StationToStationInfos"
     }
 
+    /// Create a station to station infos response
+    ///
+    /// - Parameters:
+    ///     - stationToStationInfos: List of station to station information
     public init(stationToStationInfos: [StationToStationInfo]) {
         self.stationToStationInfos = stationToStationInfos
     }
 }
 
+/// Response from the [Station to Station Information API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3313)
+/// - Tag: StationToStationInfo
 public struct StationToStationInfo: Codable {
+    /// Average of distance traveled between two stations and straight-line distance (as used for WMATA fare calculations).
     public let compositeMiles: Double
+    
+    /// Destination station
     public let destination: Station
+    
+    /// Fare information
     public let railFare: RailFare
+    
+    /// Estimated travel time (schedule time) in minutes between the source and destination station. This is not correlated to minutes (Min) in Real-Time Rail Predictions.
     public let railTime: Int
+    
+    /// Origin station
     public let source: Station
 
     enum CodingKeys: String, CodingKey {
@@ -1150,6 +1566,14 @@ public struct StationToStationInfo: Codable {
         case source = "SourceStation"
     }
 
+    /// Create a station to station info response
+    ///
+    /// - Parameters:
+    ///     - compositeMiles: Average distance travelled between two stations
+    ///     - destination: Destination station
+    ///     - railFare: Fare information
+    ///     - railTime: Estimated travel time in minuites
+    ///     - source: Origin station
     public init(
         compositeMiles: Double,
         destination: Station,
@@ -1199,9 +1623,16 @@ public struct StationToStationInfo: Codable {
     }
 }
 
+/// Response from the [Station to Station Information API](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3313)
+/// - Tag: RailFare
 public struct RailFare: Codable {
+    /// Fare during off-peak times.
     public let offPeakTime: Double
+    
+    /// Fare during peak times (weekdays from opening to 9:30 AM and 3-7 PM, and weekends from midnight to closing).
     public let peakTime: Double
+    
+    /// Reduced fare for senior citizens or people with disabilities.
     public let seniorDisabled: Double
 
     enum CodingKeys: String, CodingKey {
@@ -1210,6 +1641,12 @@ public struct RailFare: Codable {
         case seniorDisabled = "SeniorDisabled"
     }
 
+    /// Create a rail fare response
+    ///
+    /// - Parameters:
+    ///     - offPeakTime: Off-peak fare
+    ///     - peakTime: Peak fare
+    ///     - seniorDisabled: Reduced fare
     public init(
         offPeakTime: Double,
         peakTime: Double,
@@ -1221,31 +1658,65 @@ public struct RailFare: Codable {
     }
 }
 
+/// Response from the [Elevator and Escalator Incidents API](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d76)
+/// - Tag: ElevatorAndEscalatorIncidents
 public struct ElevatorAndEscalatorIncidents: Codable {
+    /// List of elevator and escalator incidents
     public let incidents: [ElevatorAndEscalatorIncident]
 
     enum CodingKeys: String, CodingKey {
         case incidents = "ElevatorIncidents"
     }
 
+    /// Create an elevator and escalator incidents response
+    ///
+    /// - Parameters:
+    ///     - incidents: List of elevator and escalator incidents
     public init(incidents: [ElevatorAndEscalatorIncident]) {
         self.incidents = incidents
     }
 }
 
+/// Response from the [Elevator and Escalator Incidents API](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d76)
+/// - Tag: ElevatorAndEscalatorIncident
 public struct ElevatorAndEscalatorIncident: Codable {
+    /// Unique identifier for unit, by type (a single elevator and escalator may have the same UnitName, but no two elevators or two escalators will have the same UnitName).
     public let unitName: String
+    
+    /// Type of unit. Will be ELEVATOR or ESCALATOR.
     public let unitType: String
+    
+    /// Warning: Deprecated. If listed here, the unit is inoperational or otherwise impaired.
     public let unitStatus: String?
+    
+    /// Station of the incident
     public let station: Station
+    
+    /// Full station name, may include entrance information (e.g.: Metro Center, G and 11th St Entrance).
     public let stationName: String
+    
+    /// Free-text description of the unit location within a station (e.g.: Escalator between mezzanine and platform).
     public let locationDescription: String
+    
+    /// Warning: Deprecated.
     public let symptomCode: String?
+    
+    /// Warning: Deprecated. Use the time portion of the DateOutOfServ element.
     public let timeOutOfService: String
+    
+    /// Description for why the unit is out of service or otherwise in reduced operation.
     public let symptomDescription: String
+    
+    /// Warning: Deprecated.
     public let displayOrder: Double
+    
+    /// Date and time (Eastern Standard Time) unit was reported out of service.
     public let dateOutOfService: Date
+    
+    /// Date and time (Eastern Standard Time) outage details was last updated.
     public let dateUpdated: String
+    
+    /// Estimated date and time (Eastern Standard Time) by when unit is expected to return to normal service.
     public let estimatedReturnToService: String
 
     enum CodingKeys: String, CodingKey {
@@ -1264,6 +1735,22 @@ public struct ElevatorAndEscalatorIncident: Codable {
         case estimatedReturnToService = "EstimatedReturnToService"
     }
 
+    /// Create a elevator and escalator incident response
+    ///
+    /// - Parameters:
+    ///     - unitName: id for unit
+    ///     - unitType: Type of unit. ELEVATOR or ESCALATOR
+    ///     - unitStatus: Deprecated.
+    ///     - station: Station of incident
+    ///     - stationName: Full name of station, including entrance information
+    ///     - locationDescription: Location of unit within station
+    ///     - symptomCode: Deprecated.
+    ///     - timeOutOfService: Deprecated.
+    ///     - symptomDescription: Why the unit is out of service
+    ///     - displayOrder: Deprecated.
+    ///     - dateOutOfService: Time unit reported out of service
+    ///     - dateUpdated: Time outage details were last updated
+    ///     - estimatedReturnToService: Time unit is expected to return to normal service
     public init(
         unitName: String,
         unitType: String,
@@ -1338,28 +1825,56 @@ public struct ElevatorAndEscalatorIncident: Codable {
     }
 }
 
+/// Response from the [Rail Incidents API](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d77)
+/// - Tag: RailIncidents
 public struct RailIncidents: Codable {
+    /// List of rail incidents
     public let incidents: [RailIncident]
 
     enum CodingKeys: String, CodingKey {
         case incidents = "Incidents"
     }
 
+    /// Create a rail incidents response
+    ///
+    /// - Parameters:
+    ///     - incidents: List of rail incidents
     public init(incidents: [RailIncident]) {
         self.incidents = incidents
     }
 }
 
+/// Response from the [Rail Incidents API](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d77)
+/// - Tag: RailIncident
 public struct RailIncident: Codable {
+    /// Unique identifier for an incident.
     public let incidentID: String
+    
+    /// Free-text description of the incident.
     public let description: String
+    
+    /// Warning: Deprecated.
     public let startLocationFullName: String?
+    
+    /// Warning: Deprecated.
     public let endLocationFullName: String?
+    
+    /// Warning: Deprecated.
     public let passengerDelay: Double
+    
+    /// Warning: Deprecated.
     public let delaySeverity: String?
+    
+    /// Free-text description of the incident type. Usually Delay or Alert but is subject to change at any time.
     public let incidentType: String
+    
+    /// Warning: Deprecated.
     public let emergencyText: String?
+    
+    /// Semi-colon and space separated list of line codes (e.g.: RD; or BL; OR; or BL; OR; RD;). =(
     public let linesAffected: String
+    
+    /// Date and time (Eastern Standard Time) of last update.
     public let dateUpdated: Date
 
     enum CodingKeys: String, CodingKey {
@@ -1375,6 +1890,19 @@ public struct RailIncident: Codable {
         case dateUpdated = "DateUpdated"
     }
 
+    /// Create a rail incident response
+    ///
+    /// - Parameters:
+    ///     - incidentID: Unique ID for incident
+    ///     - description: Description of incident
+    ///     - startLocationFullName: Deprecated.
+    ///     - endLocationFullName: Deprecated.
+    ///     - passengerDelay: Deprecated.
+    ///     - delaySeverity: Deprecated.
+    ///     - incidentType: Type of incident
+    ///     - emergencyText: Deprecated.
+    ///     - linesAffected: Semi-color and space separated list of line codes. (e.g.: RD; or BL; OR; or BL; OR; RD;). =(
+    ///     - dateUpdated: TIme of last status update
     public init(
         incidentID: String,
         description: String,

--- a/Sources/WMATA/Rail/Stations.swift
+++ b/Sources/WMATA/Rail/Stations.swift
@@ -123,6 +123,9 @@ extension Station: NeedsStation {}
 public extension Station {
     /// Distance, fare information, and estimated travel time between this and another station.
     ///
+    /// - Note:
+    ///     [WMATA Station To Station Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3313)
+    ///
     /// - Parameters:
     ///     - destinationStation: Optional. Station to travel to
     ///     - key: WMATA API Key to use with this request
@@ -135,6 +138,9 @@ public extension Station {
 
     /// Reported elevator and escalator incidents at this Station
     ///
+    /// - Note:
+    ///     [WMATA Elevator and Escalator Incidents](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d76)
+    ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request
     ///     - session: Optional. URL Session to make this request with
@@ -145,6 +151,9 @@ public extension Station {
     }
 
     /// Reported MetroRail incidents at this Station
+    ///
+    /// - Note:
+    ///     [WMATA Station Incidents Documentation](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d77)
     ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request
@@ -157,6 +166,9 @@ public extension Station {
 
     ///  Next train arrival information for this Station
     ///
+    /// - Note:
+    ///     [WMATA Next Trains Documentation](https://developer.wmata.com/docs/services/547636a6f9182302184cda78/operations/547636a6f918230da855363f)
+    ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request
     ///     - session: Optional. URL Session to make this request with
@@ -167,6 +179,9 @@ public extension Station {
     }
 
     /// Location and address information for this Station
+    ///
+    /// - Note:
+    ///     [WMATA Station Information Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3310)
     ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request
@@ -179,6 +194,9 @@ public extension Station {
 
     /// Parking information for this Station
     ///
+    /// - Note:
+    ///     [WMATA Parking Information Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330d)
+    ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request
     ///     - session: Optional. URL Session to make this request with
@@ -189,6 +207,9 @@ public extension Station {
     }
 
     /// Returns a set of ordered stations and distances from this Station to another Station _on the same line_
+    ///
+    /// - Note:
+    ///     [WMATA Path Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330e)
     ///
     /// - Parameters:
     ///     - destinationStation: Destination station to pathfind to
@@ -202,12 +223,15 @@ public extension Station {
 
     /// Opening and scheduled first and last trains for this Station
     ///
+    /// - Note:
+    ///     [WMATA Timings Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3312)
+    ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request
     ///     - session: Optional. URL Session to make this request with
     ///     - completion: A completion handler
     ///     - result: [StationTimings](x-source-tag://StationTimings) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
-    func timings(key: String, session: URLSession = URLSession.shared, completion: @escaping (Result<StationTimings, WMATAError>) -> Void) {
+    func timings(key: String, session: URLSession = URLSession.shared, completion: @escaping (_ result: Result<StationTimings, WMATAError>) -> Void) {
         (self as NeedsStation).timings(for: self, key: key, session: session, completion: completion)
     }
 }
@@ -215,6 +239,9 @@ public extension Station {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public extension Station {
     /// Distance, fare information, and estimated travel time between this and another station.
+    ///
+    /// - Note:
+    ///     [WMATA Station To Station Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3313)
     ///
     /// - Parameters:
     ///     - destinationStation: Optional. Station to travel to
@@ -228,6 +255,9 @@ public extension Station {
 
     /// Reported elevator and escalator incidents at this Station
     ///
+    /// - Note:
+    ///     [WMATA Elevator and Escalator Incidents Documentation](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d76)
+    ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request
     ///     - session: Optional. URL Session to make this request with
@@ -238,6 +268,9 @@ public extension Station {
     }
 
     /// Reported MetroRail incidents at this Station
+    ///
+    /// - Note:
+    ///     [WMATA Station Incidents Documentation](https://developer.wmata.com/docs/services/54763641281d83086473f232/operations/54763641281d830c946a3d77)
     ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request
@@ -250,6 +283,9 @@ public extension Station {
 
     ///  Next train arrival information for this Station
     ///
+    ///  - Note:
+    ///     [WMATA Next Trains Documentation](https://developer.wmata.com/docs/services/547636a6f9182302184cda78/operations/547636a6f918230da855363f)
+    ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request
     ///     - session: Optional. URL Session to make this request with
@@ -260,6 +296,9 @@ public extension Station {
     }
 
     /// Location and address information for this Station
+    ///
+    /// - Note:
+    ///     [WMATA Station Information Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3310)
     ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request
@@ -272,6 +311,9 @@ public extension Station {
 
     /// Parking information for this Station
     ///
+    /// - Note:
+    ///     [WMATA Parking Information Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330d)
+    ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request
     ///     - session: Optional. URL Session to make this request with
@@ -282,6 +324,9 @@ public extension Station {
     }
 
     /// Returns a set of ordered stations and distances from this Station to another Station _on the same line_
+    ///
+    /// - Note:
+    ///     [WMATA Path Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330e)
     ///
     /// - Parameters:
     ///     - destinationStation: Destination station to pathfind to
@@ -294,6 +339,9 @@ public extension Station {
     }
 
     /// Opening and scheduled first and last trains for this Station
+    ///
+    /// - Note:
+    ///     [WMATA Timings Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3312)
     ///
     /// - Parameters:
     ///     - key: WMATA API Key to use with this request
@@ -675,8 +723,11 @@ public extension Station {
     }
 
     /// The opening time for this station on the given date.
-    /// - Parameter date: Date to check the opening time for. Omit for today.
-    /// - Returns: The time
+    ///
+    /// - Parameters:
+    ///     - date: Date to check the opening time for. Omit for today.
+    ///
+    /// - Returns: The opening time
     func openingTime(on date: Date? = nil) -> Date {
         let day: WeekdaySaturdayOrSunday
         let openingDate: Date
@@ -704,7 +755,10 @@ public extension Station {
     }
 
     /// The station located within the same physical station as this station.
-    /// Details: https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3310
+    ///
+    /// - Note:
+    ///     [WMATA Station Information Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3310)
+    ///
     /// - Returns: The `Station` within the same physical station.
     var together: Station? {
         switch self {
@@ -734,9 +788,12 @@ public extension Station {
     }
 
     /// Combines this station and other stations within the same physical station.
-    /// Details: https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3310
     /// This is effectively the result of joining the `StationTogether1`
     /// and `StationTogether2` values from the WMATA API.
+    ///
+    /// - Note:
+    ///     [WMATA Station Information Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe3310)
+    ///
     /// - Returns: An array containing this station and the `Station` `together`, if there is one.
     var allTogether: [Station] {
         if let together = self.together {

--- a/Sources/WMATA/Rail/Stations.swift
+++ b/Sources/WMATA/Rail/Stations.swift
@@ -122,67 +122,91 @@ extension Station: NeedsStation {}
 
 public extension Station {
     /// Distance, fare information, and estimated travel time between this and another station.
-    /// - Parameter destinationStation: Optional. Station to travel to
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - Parameter completion: completion that returns `StationToStationInfos`
-    func station(to destinationStation: Station?, key: String, session: URLSession = URLSession.shared, completion: @escaping (Result<StationToStationInfos, WMATAError>) -> Void) {
+    ///
+    /// - Parameters:
+    ///     - destinationStation: Optional. Station to travel to
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///     - completion: A completion handler
+    ///     - result: [StationToStationInfos](x-source-tag://StationToStationInfos) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func station(to destinationStation: Station? = nil, key: String, session: URLSession = URLSession.shared, completion: @escaping (_ result: Result<StationToStationInfos, WMATAError>) -> Void) {
         (self as NeedsStation).station(self, to: destinationStation, key: key, session: session, completion: completion)
     }
 
     /// Reported elevator and escalator incidents at this Station
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - Parameter completion: completion handler that returns `ElevatorAndEscalatorIncidents`
-    func elevatorAndEscalatorIncidents(key: String, session: URLSession = URLSession.shared, completion: @escaping (Result<ElevatorAndEscalatorIncidents, WMATAError>) -> Void) {
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///     - completion: A completion handler
+    ///     - result: [ElevatorAndEscalatorIncidents](x-source-tag://ElevatorAndEscalatorIncidents) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func elevatorAndEscalatorIncidents(key: String, session: URLSession = URLSession.shared, completion: @escaping (_ result: Result<ElevatorAndEscalatorIncidents, WMATAError>) -> Void) {
         (self as NeedsStation).elevatorAndEscalatorIncidents(at: self, key: key, session: session, completion: completion)
     }
 
     /// Reported MetroRail incidents at this Station
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - Parameter completion: completion handler that returns `RailIncidents`
-    func incidents(key: String, session: URLSession = URLSession.shared, completion: @escaping (Result<RailIncidents, WMATAError>) -> Void) {
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///     - completion: A completion handler
+    ///     - result: [RailIncidents](x-source-tag://RailIncidents) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func incidents(key: String, session: URLSession = URLSession.shared, completion: @escaping (_ result: Result<RailIncidents, WMATAError>) -> Void) {
         (self as NeedsStation).incidents(at: self, key: key, session: session, completion: completion)
     }
 
     ///  Next train arrival information for this Station
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - Parameter completion: completion handler that returns `RailPredictions`
-    func nextTrains(key: String, session: URLSession = URLSession.shared, completion: @escaping (Result<RailPredictions, WMATAError>) -> Void) {
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///     - completion: A completion handler
+    ///     - result: [RailPredictions](x-source-tag://RailPredictions) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func nextTrains(key: String, session: URLSession = URLSession.shared, completion: @escaping (_ result: Result<RailPredictions, WMATAError>) -> Void) {
         (self as NeedsStation).nextTrains(at: self, key: key, session: session, completion: completion)
     }
 
     /// Location and address information for this Station
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - Parameter completion: completion handler that returns `StationInformation`
-    func information(key: String, session: URLSession = URLSession.shared, completion: @escaping (Result<StationInformation, WMATAError>) -> Void) {
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///     - completion: A completion handler
+    ///     - result: [StationInformation](x-source-tag://StationInformation) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func information(key: String, session: URLSession = URLSession.shared, completion: @escaping (_ result: Result<StationInformation, WMATAError>) -> Void) {
         (self as NeedsStation).information(for: self, key: key, session: session, completion: completion)
     }
 
     /// Parking information for this Station
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - Parameter completion: completion handler that returns `StationsParking`
-    func parkingInformation(key: String, session: URLSession = URLSession.shared, completion: @escaping (Result<StationsParking, WMATAError>) -> Void) {
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///     - completion: A completion handler
+    ///     - result: [StationsParking](x-source-tag://StationsParking) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func parkingInformation(key: String, session: URLSession = URLSession.shared, completion: @escaping (_ result: Result<StationsParking, WMATAError>) -> Void) {
         (self as NeedsStation).parkingInformation(for: self, key: key, session: session, completion: completion)
     }
 
     /// Returns a set of ordered stations and distances from this Station to another Station _on the same line_
-    /// - Parameter destinationStation: Destination station to pathfind to
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - Parameter completion: completion handler that returns `PathBetweenStations`
-    func path(to destinationStation: Station, key: String, session: URLSession = URLSession.shared, completion: @escaping (Result<PathBetweenStations, WMATAError>) -> Void) {
+    ///
+    /// - Parameters:
+    ///     - destinationStation: Destination station to pathfind to
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///     - completion: A completion handler
+    ///     - result: [PathBetweenStations](x-source-tag://PathBetweenStations) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
+    func path(to destinationStation: Station, key: String, session: URLSession = URLSession.shared, completion: @escaping (_ result: Result<PathBetweenStations, WMATAError>) -> Void) {
         (self as NeedsStation).path(from: self, to: destinationStation, key: key, session: session, completion: completion)
     }
 
     /// Opening and scheduled first and last trains for this Station
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - Parameter completion: completion handler that returns `StationTimings`
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///     - completion: A completion handler
+    ///     - result: [StationTimings](x-source-tag://StationTimings) if successful, otherwise [WMATAError](x-source-tag://WMATAError)
     func timings(key: String, session: URLSession = URLSession.shared, completion: @escaping (Result<StationTimings, WMATAError>) -> Void) {
         (self as NeedsStation).timings(for: self, key: key, session: session, completion: completion)
     }
@@ -191,67 +215,91 @@ public extension Station {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public extension Station {
     /// Distance, fare information, and estimated travel time between this and another station.
-    /// - Parameter destinationStation: Optional. Station to travel to
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - returns: A Combine Publisher for `StationToStationInfos`
-    func stationPublisher(to destinationStation: Station?, key: String, session: URLSession = URLSession.shared) -> AnyPublisher<StationToStationInfos, WMATAError> {
+    ///
+    /// - Parameters:
+    ///     - destinationStation: Optional. Station to travel to
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///
+    /// - Returns: A Combine Publisher for [StationToStationInfos](x-source-tag://StationToStationInfos)
+    func stationPublisher(to destinationStation: Station? = nil, key: String, session: URLSession = URLSession.shared) -> AnyPublisher<StationToStationInfos, WMATAError> {
         (self as NeedsStation).stationPublisher(self, to: destinationStation, key: key, session: session)
     }
 
     /// Reported elevator and escalator incidents at this Station
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - returns: A Combine Publisher for `ElevatorAndEscalatorIncidents`
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///
+    /// - Returns: A Combine Publisher for [ElevatorAndEscalatorIncidents](x-source-tag://ElevatorAndEscalatorIncidents)
     func elevatorAndEscalatorIncidentsPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<ElevatorAndEscalatorIncidents, WMATAError> {
         (self as NeedsStation).elevatorAndEscalatorIncidentsPublisher(at: self, key: key, session: session)
     }
 
     /// Reported MetroRail incidents at this Station
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - returns: A Combine Publisher for `RailIncidents`
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///
+    /// - Returns: A Combine Publisher for [RailIncidents](x-source-tag://RailIncidents)
     func incidentsPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<RailIncidents, WMATAError> {
         (self as NeedsStation).incidentsPublisher(at: self, key: key, session: session)
     }
 
     ///  Next train arrival information for this Station
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - returns: A Combine Publisher for  `RailPredictions`
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///
+    /// - Returns: A Combine Publisher for [RailPredictions](x-source-tag://RailPredictions)
     func nextTrainsPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<RailPredictions, WMATAError> {
         (self as NeedsStation).nextTrainsPublisher(at: self, key: key, session: session)
     }
 
     /// Location and address information for this Station
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - returns: A Combine Publisher for `StationInformation`
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///
+    /// - Returns: A Combine Publisher for [StationInformation](x-source-tag://StationInformation)
     func informationPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<StationInformation, WMATAError> {
         (self as NeedsStation).informationPublisher(for: self, key: key, session: session)
     }
 
     /// Parking information for this Station
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - returns: A Combine Publisher for `StationsParking`
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///
+    /// - Returns: A Combine Publisher for [StationsParking](x-source-tag://StationsParking)
     func parkingInformationPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<StationsParking, WMATAError> {
         (self as NeedsStation).parkingInformationPublisher(for: self, key: key, session: session)
     }
 
     /// Returns a set of ordered stations and distances from this Station to another Station _on the same line_
-    /// - Parameter destinationStation: Destination station to pathfind to
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - returns: A Combine Publisher for `PathBetweenStations`
+    ///
+    /// - Parameters:
+    ///     - destinationStation: Destination station to pathfind to
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///
+    /// - Returns: A Combine Publisher for [PathBetweenStations](x-source-tag://PathBetweenStations)
     func pathPublisher(to destinationStation: Station, key: String, session: URLSession = URLSession.shared) -> AnyPublisher<PathBetweenStations, WMATAError> {
         (self as NeedsStation).pathPublisher(from: self, to: destinationStation, key: key, session: session)
     }
 
     /// Opening and scheduled first and last trains for this Station
-    /// - Parameter key: WMATA API Key to use with this request
-    /// - Parameter session: Optional. URL Session to make this request with
-    /// - returns: A Combine Publisher for `StationTimings`
+    ///
+    /// - Parameters:
+    ///     - key: WMATA API Key to use with this request
+    ///     - session: Optional. URL Session to make this request with
+    ///
+    /// - Returns: A Combine Publisher for [StationTimings](x-source-tag://StationTimings)
     func timingsPublisher(key: String, session: URLSession = URLSession.shared) -> AnyPublisher<StationTimings, WMATAError> {
         (self as NeedsStation).timingsPublisher(for: self, key: key, session: session)
     }

--- a/Sources/WMATA/Requests.swift
+++ b/Sources/WMATA/Requests.swift
@@ -14,10 +14,12 @@ protocol Requester {}
 extension Requester {
     /// Default implementation for sending an HTTP request.
     ///
-    /// - parameter request: The URLRequest to send
-    /// - parameter session: Session to run URLRequest with
-    /// - parameter completion: Completion handler to receive output of request.
-    func request(request: URLRequest, session: URLSession, completion: @escaping (Result<Data, WMATAError>) -> Void) {
+    /// - Parameters:
+    ///     - request: The URLRequest to send
+    ///     - session: Session to run URLRequest with
+    ///     - completion: A completion handler
+    ///     - result: Data of response or [WMATAError](x-source-tag://WMATAError)
+    func request(request: URLRequest, session: URLSession, completion: @escaping (_ result: Result<Data, WMATAError>) -> Void) {
         session.dataTask(with: request) { data, _, error in
             guard let populatedData = data else {
                 if let populatedError = error {
@@ -58,8 +60,8 @@ extension Fetcher {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Fetcher {
-    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func publisher<T: Codable>(request: URLRequest, session: URLSession) -> AnyPublisher<T, WMATAError> {
         session
             .dataTaskPublisher(for: request)


### PR DESCRIPTION
Changes:
 - Documentation added to all responses and responses fields
 - Standardize documentation formatting
 - Add links to WMATA documentation at appropriate call points
 - Return a `Date` for `time` in the `StopInfo` response rather than a `String`
 - Fix #18, appropriately encode and decode Route instances
 - Properly encode `Stop` instances
 - Add documentation to `RadiusAtCoordinates`, `Coordinates` and `WMATADate`
 - Added default `nil` values to many calls
 - Add documentation on delegate calls to the corresponding method on `WMATADelegate` 