### PR TITLE
Add methods to get connecting lines at stations

### DIFF
--- a/Sources/WMATA/Station.swift
+++ b/Sources/WMATA/Station.swift
@@ -583,6 +583,24 @@ public extension Station {
 
         return [self]
     }
+
+    /// Get the connecting lines at this station for the given line.
+    ///
+    /// - Parameter to: The line to get connections for; if nil, returns all lines at this station.
+    ///
+    /// - Returns: An array of connecting lines; this is empty if the `to` line is the only line at this station.
+    func connections(to line: Line?) -> [Line] {
+        self.lines.filter({ $0 != line })
+    }
+
+    /// Get the connecting lines at this station and any station together with it for the given line.
+    ///
+    /// - Parameter to: The line to get connections for; if nil, returns all lines at this station.
+    ///
+    /// - Returns: An array of connecting lines; this is empty if the `to` line is the only line at this station.
+    func allConnections(to line: Line?) -> [Line] {
+        self.allTogether.flatMap({ $0.connections(to: line) })
+    }
 }
 
 extension Station: URLQueryItemConvertible {

--- a/Tests/WMATATests/TestStation.swift
+++ b/Tests/WMATATests/TestStation.swift
@@ -70,4 +70,18 @@ final class StationTests: XCTestCase {
         XCTAssertEqual(Station.metroCenterLower.allTogether, [Station.metroCenterLower, Station.metroCenterUpper])
         XCTAssertEqual(Station.farragutNorth.allTogether, [Station.farragutNorth])
     }
+
+    func testConnections() {
+        XCTAssertEqual([], Station.farragutNorth.connections(to: .red))
+        XCTAssertEqual([.red], Station.farragutNorth.connections(to: nil))
+        XCTAssertEqual([.yellow], Station.fortTottenLower.connections(to: .green))
+        XCTAssertEqual([.green, .yellow], Station.fortTottenLower.connections(to: nil))
+    }
+
+    func testAllConnections() {
+        XCTAssertEqual([], Station.farragutNorth.allConnections(to: .red))
+        XCTAssertEqual([.red], Station.farragutNorth.allConnections(to: nil))
+        XCTAssertEqual([.yellow, .red], Station.fortTottenLower.allConnections(to: .green))
+        XCTAssertEqual([.green, .yellow, .red], Station.fortTottenLower.allConnections(to: nil))
+    }
 }


### PR DESCRIPTION
This is two convenience methods to get the connecting lines at a station, or to get the all the connecting lines at a station when that station is together at another station. While I expect that `allConnections` is the only useful method in this commit, `connections` is included for completeness.