### PR TITLE
Single source of truth for open stations and current lines

### DIFF
--- a/Sources/WMATA/Line.swift
+++ b/Sources/WMATA/Line.swift
@@ -68,12 +68,7 @@ public extension Line {
     ///
     /// True for all other lines.
     var current: Bool {
-        switch self {
-        case .red, .blue, .yellow, .orange, .green, .silver:
-            return true
-        case .yellowLineRushPlus:
-            return false
-        }
+        Line.allCurrent.contains(self)
     }
     
     /// All of the current Lines. ``YLRP`` is not included.

--- a/Sources/WMATA/Station.swift
+++ b/Sources/WMATA/Station.swift
@@ -483,12 +483,7 @@ public extension Station {
     ///
     /// - Returns: `false` if a station is part of the Potomac Yard or Silver Line Phase 2 expansions. Otherwise `true`.
     var open: Bool {
-        switch self {
-        case .restonTownCenter, .herndon, .innovationCenter, .dullesInternationalAirport, .loudounGateway, .ashburn, .potomacYard:
-            return false
-        default:
-            return true
-        }
+        Station.allOpen.contains(self)
     }
     
     /// All stations that are currently open to the public.

--- a/Tests/WMATATests/TestLine.swift
+++ b/Tests/WMATATests/TestLine.swift
@@ -1,0 +1,19 @@
+//
+//  TestLine.swift
+//  
+//
+//  Created by Randall Wood on 2021-12-30.
+//
+
+@testable import WMATA
+import XCTest
+
+class LineTests: XCTestCase {
+
+    func testCurrent() {
+        Line.allCurrent.forEach({ XCTAssertTrue($0.current, "expected \($0) to be current") })
+        Line.allCases
+            .filter({ !Line.allCurrent.contains($0) })
+            .forEach({ XCTAssertFalse($0.current, "expected \($0) to not be current") })
+    }
+}

--- a/Tests/WMATATests/TestStation.swift
+++ b/Tests/WMATATests/TestStation.swift
@@ -70,4 +70,11 @@ final class StationTests: XCTestCase {
         XCTAssertEqual(Station.metroCenterLower.allTogether, [Station.metroCenterLower, Station.metroCenterUpper])
         XCTAssertEqual(Station.farragutNorth.allTogether, [Station.farragutNorth])
     }
+
+    func testOpen() {
+        Station.allOpen.forEach({ XCTAssertTrue($0.open, "expected \($0) to be open") })
+        Station.allCases
+            .filter({ !Station.allOpen.contains($0) })
+            .forEach({ XCTAssertFalse($0.open, "expected \($0) to be closed") })
+    }
 }


### PR DESCRIPTION
A station being open or a line being current has two sources of truth in them. I though this might make maintenance just a little easier by providing a single source of truth for those two properties.