### PR TITLE
Allow NextTrain API request to use [Station]

### DIFF
--- a/Sources/WMATA/Rail.swift
+++ b/Sources/WMATA/Rail.swift
@@ -1100,6 +1100,22 @@ public extension Rail {
             self.delegate = delegate
         }
         
+        /// Create a Next Trains call for multiple stations
+        ///
+        /// - Parameters
+        ///     - key: WMATA API Key for this request
+        ///     - stations: The stations to get the next trains for
+        ///     - delegate: Delegate to send background requests to
+        public init(
+            key: APIKey,
+            stations: [Station],
+            delegate: JSONEndpointDelegate<Rail.NextTrains>? = nil
+        ) {
+            self.key = key
+            self.stations = StationSet(stations)
+            self.delegate = delegate
+        }
+        
         /// Create a Next Trains call for a single station
         ///
         /// - Parameters

--- a/Tests/WMATATests/TestRail.swift
+++ b/Tests/WMATATests/TestRail.swift
@@ -517,7 +517,7 @@ final class RailTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
-    func testNextTrains() {
+    func testNextTrainsStationSet() {
         let exp = expectation(description: name)
         let predictions = Rail.NextTrains(
             key: TEST_API_KEY,
@@ -537,7 +537,7 @@ final class RailTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
-    func testNextTrainsWithDelegate() {
+    func testNextTrainsStationSetWithDelegate() {
         let delegate = TestJSONDelegate<Rail.NextTrains>(expectation: expectation(description: name))
 
         let predictions = Rail.NextTrains(
@@ -550,7 +550,41 @@ final class RailTests: XCTestCase {
 
         waitForExpectations(timeout: 1)
     }
-    
+
+    func testNextTrainsArray() {
+        let exp = expectation(description: name)
+        let predictions = Rail.NextTrains(
+            key: TEST_API_KEY,
+            stations: Station.metroCenterUpper.allTogether
+        )
+
+        predictions.request { result in
+            switch result {
+            case .success:
+                exp.fulfill()
+
+            case let .failure(error):
+                print(error)
+            }
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+
+    func testNextTrainsArrayWithDelegate() {
+        let delegate = TestJSONDelegate<Rail.NextTrains>(expectation: expectation(description: name))
+
+        let predictions = Rail.NextTrains(
+            key: TEST_API_KEY,
+            stations: Station.metroCenterUpper.allTogether,
+            delegate: delegate
+        )
+
+        predictions.backgroundRequest()
+
+        waitForExpectations(timeout: 1)
+    }
+
     func testNextTrainsAll() {
         let exp = expectation(description: name)
         let predictions = Rail.NextTrains(


### PR DESCRIPTION
This allows an app where the next trains for a single (by name or address, not by API) station is shown, and the following code always works to get the arrivals at all platforms at the station:
```
var myStation: Station
...myStation is set through some process (user selection, geolocation, etc)...
let predictions = Rail.NextTrains(key: myKey, stations: myStation.allTogether)
```
without the developer's need to identify that `myStation` is or is not together with another station and without needing to use `Rail.NextTrains(key: myKey, stations: Rail.NextTrains.StationSet(myStation.allTogether))` which seems a bit awkward given that array literals are directly usable as the `stations` parameter but array values are not.