### PR TITLE
feat!: Remove StationSet

### DIFF
--- a/Sources/WMATA/Station.swift
+++ b/Sources/WMATA/Station.swift
@@ -609,3 +609,17 @@ extension Station: URLQueryItemConvertible {
         URLQueryItem(name: name.rawValue, value: rawValue)
     }
 }
+
+public extension Array where Element == Station {
+    /// Both L'Enfant Plaza platforms
+    static let lenfantPlaza: [Station] = [.lenfantPlazaLower, .lenfantPlazaUpper]
+   
+   /// Both Metro Center platforms
+    static let metroCenter: [Station]  = [.metroCenterLower, .metroCenterUpper]
+   
+   /// Both Fort Totten platforms
+    static let fortTotten: [Station]  = [.fortTottenLower, .fortTottenUpper]
+   
+   /// Both Gallery Place platforms
+    static let galleryPlace: [Station]  = [.galleryPlaceLower, .galleryPlaceUpper]
+}

--- a/Tests/WMATATests/TestRail.swift
+++ b/Tests/WMATATests/TestRail.swift
@@ -554,8 +554,7 @@ final class RailTests: XCTestCase {
     func testNextTrainsAll() {
         let exp = expectation(description: name)
         let predictions = Rail.NextTrains(
-            key: TEST_API_KEY,
-            stations: .all
+            key: TEST_API_KEY
         )
 
         predictions.request { result in
@@ -576,7 +575,6 @@ final class RailTests: XCTestCase {
 
         let predictions = Rail.NextTrains(
             key: TEST_API_KEY,
-            stations: .all,
             delegate: delegate
         )
 

--- a/Tests/WMATATests/TestRailDVR.swift
+++ b/Tests/WMATATests/TestRailDVR.swift
@@ -348,10 +348,7 @@ final class TestRailDVR: DVRTestCase {
     }
     
     func testNextTrainsAll() {
-        let nextTrains = Rail.NextTrains(
-            key: TEST_API_KEY,
-            stations: .all
-        )
+        let nextTrains = Rail.NextTrains(key: TEST_API_KEY)
     
         nextTrains.request(with: session) { [weak self] result in
             switch result {


### PR DESCRIPTION
feat!: Use `[Station]` for multi station initializer for Rail.NextTrains instead of `StationSet`
feat!: move multi-platform station lists from StationSet to Array.

BREAKING CHANGE: StationSet removed in favor of using Arrays and nil to represent multiple or all stations in Rail.NextTrains.

Alternate implementation to #30 

These changes should allow for code like
```swift
let nextTrains = Rail.NextTrains(
    key: API_KEY,
    stations: myStation.allTogether
)
```
as mentioned in #30, and
```swift
let nextTrains = Rail.NextTrains(
    key: API_KEY,
    stations: .fortTotten
)
```
with the new `Array` extension. While maintaining previously possible code like
```
```swift
let nextTrains = Rail.NextTrains(
    key: API_KEY,
    stations: [.waterfront, .tenleytown]
)
```