### PR TITLE
doc: Use WMATA styling for service names

### DIFF
--- a/Sources/WMATA/Bus.swift
+++ b/Sources/WMATA/Bus.swift
@@ -8,18 +8,18 @@
 import Foundation
 import GTFS
 
-/// MetroBus endpoints
+/// Metrobus endpoints
 ///
-/// The various endpoints defined here allow you to call MetroBus APIs. For an overview see <doc:Endpoints>
+/// The various endpoints defined here allow you to call Metrobus APIs. For an overview see <doc:Endpoints>
 ///
 /// > Tip: You can use endpoints here like so: `Bus.Routes(...)`
 public enum Bus {
-    /// MetroBus GTFS endpoints
+    /// Metrobus GTFS endpoints
     public enum GTFS {}
 }
 
 public extension Bus {
-    /// Locations of MetroBuses
+    /// Locations of Metrobus Buses
     ///
     /// Omit both `route` and `location` to receive positions for all buses.
     ///
@@ -162,7 +162,7 @@ public extension Bus {
         }
     }
     
-    /// Reported delays or incidents for MetroBuses
+    /// Reported delays or incidents for Metrobus Buses
     ///
     /// Omit `route` to receive incidents for all buses.
     ///
@@ -207,7 +207,7 @@ public extension Bus {
                 self.busIncidents = busIncidents
             }
             
-            /// A MetroBus incident
+            /// A Metrobus incident
             public struct Incident: Codable, Equatable, Hashable {
                 /// Date and time (Eastern Standard Time) of last update.
                 public let dateUpdated: Date
@@ -282,7 +282,7 @@ public extension Bus {
         
         public struct Response: Codable, Equatable, Hashable {
             
-            /// MetroBus route
+            /// Metrobus route
             public let route: Route
             
             /// Descriptive name for the route.
@@ -573,7 +573,7 @@ public extension Bus {
                 
                 /// Information about a ``Stop``
                 public struct StopInfo: Codable, Equatable, Hashable {
-                    /// A MetroBus stop
+                    /// A Metrobus stop
                     /// > Warning: A `stop` of `0` incidates an unknown stop.
                     public let stop: Stop?
                     
@@ -589,7 +589,7 @@ public extension Bus {
                     /// Create a stop info response
                     ///
                     /// - Parameters:
-                    ///     - stop: A MetroBus stop
+                    ///     - stop: A Metrobus stop
                     ///     - stopName: Name of stop
                     ///     - stopSequence: Order of the stop in sequence
                     ///     - time: Scheduled departure time from this stop
@@ -623,7 +623,7 @@ public extension Bus {
         
         public let key: APIKey
         
-        // A MetroBus stop
+        // A Metrobus stop
         public let stop: Stop
         
         public weak var delegate: JSONEndpointDelegate<Self>? = nil
@@ -650,7 +650,7 @@ public extension Bus {
                 self.stopName = stopName
             }
             
-            /// An arrival time prediction for a MetroBus
+            /// An arrival time prediction for a bus
             public struct Prediction: Codable, Equatable, Hashable {
                 /// Denotes a binary direction (0 or 1) of the bus.
                 ///
@@ -719,7 +719,7 @@ public extension Bus {
         
         public let key: APIKey
         
-        // A MetroBus stop
+        // A Metrobus stop
         public let stop: Stop
         
         // Date to receive this stop's schedule for. Omit for current date.
@@ -797,7 +797,7 @@ public extension Bus {
                 ///     - directionNumber: `"0"` or `"1"`
                 ///     - startTime: Start time of this trip
                 ///     - endTime: End time of this trip
-                ///     - route: MetroBus route. Can include variants.
+                ///     - route: Metrobus route. Can include variants.
                 ///     - tripDirectionText: General direction of bus
                 ///     - tripHeadsign: Destination of bus
                 ///     - tripID: Trip Identifier
@@ -824,7 +824,7 @@ public extension Bus {
             
             /// A stop schedule
             public struct StopSchedule: Codable, Equatable, Hashable {
-                /// A MetroBus stop
+                /// A Metrobus stop
                 @MapToNil<Stop, SingleZero> public var stop: Stop?
                 
                 /// Stop name.
@@ -868,7 +868,7 @@ public extension Bus {
         }
     }
     
-    /// MetroBus ``Stop``s within a ``WMATALocation``.
+    /// Metrobus ``Stop``s within a ``WMATALocation``.
     ///
     /// Omit `location` to retrieve a list of all ``Stop``s.
     ///
@@ -909,7 +909,7 @@ public extension Bus {
             
             /// A stop schedule
             public struct StopSchedule: Codable, Equatable, Hashable {
-                /// A MetroBus stop
+                /// A Metrobus stop
                 @MapToNil<Stop, SingleZero> public var stop: Stop?
                 
                 /// Stop name.
@@ -931,7 +931,7 @@ public extension Bus {
                 /// Create a stop schedule response
                 ///
                 /// - Parameters:
-                ///     - stop: A MetroBus stop
+                ///     - stop: A Metrobus stop
                 ///     - name: Stop name
                 ///     - latitude: Latitude of stop
                 ///     - longitude: Longitude of stop
@@ -953,7 +953,7 @@ public extension Bus {
         }
     }
     
-    /// All MetroBus ``Route``  and variants
+    /// All Metrobus ``Route``  and variants
     ///
     /// For example, the `10A` and `10Av1` are the same route, but may stop at slightly different locations.
     struct Routes: JSONEndpoint {
@@ -986,11 +986,11 @@ public extension Bus {
                 self.routes = routes
             }
             
-            /// A MetroBus route.
+            /// A Metrobus route.
             ///
             /// Different than ``WMATA/Route``
             public struct Route: Codable, Equatable, Hashable {
-                /// A MetroBus route
+                /// A Metrobus route
                 public let route: WMATA.Route
                 
                 /// Descriptive name of the route variant.
@@ -1004,7 +1004,7 @@ public extension Bus {
                 /// Create a route response
                 ///
                 /// - Parameters:
-                ///     - route: A MetroBus route
+                ///     - route: A Metrobus route
                 ///     - name: Name of the route variant, i.e. `10A`, `10Av1`
                 ///     - lineDescription: Route variant's grouping
                 public init(
@@ -1023,9 +1023,9 @@ public extension Bus {
 
 public extension Bus.GTFS {
     
-    /// GTFS 1.0 Service Alerts feed for MetroBus
+    /// GTFS 1.0 Service Alerts feed for Metrobus
     ///
-    /// Service alerts represent higher level problems with buses, routes or all of MetroBus
+    /// Service alerts represent higher level problems with buses, routes or all of Metrobus
     ///
     /// [GTFS Alerts Documentation](https://gtfs.org/reference/realtime/v1/#message-alert)
     struct Alerts: GTFSEndpoint {
@@ -1041,7 +1041,7 @@ public extension Bus.GTFS {
         public weak var delegate: GTFSEndpointDelegate<Self>? = nil
     }
     
-    /// GTFS 1.0 Trip Updates feed for MetroBus
+    /// GTFS 1.0 Trip Updates feed for Metrobus
     ///
     /// Trip updates represent fluctuations in the timetable
     ///
@@ -1059,9 +1059,9 @@ public extension Bus.GTFS {
         public weak var delegate: GTFSEndpointDelegate<Self>? = nil
     }
     
-    /// GTFS 1.0 Vehicle Positions feed for MetroBus
+    /// GTFS 1.0 Vehicle Positions feed for Metrobus
     ///
-    /// Locations of MetroBuses
+    /// Locations of Metrobus Buses
     ///
     /// [GTFS Trip Updates Documentation](https://gtfs.org/reference/realtime/v1/#message-vehicleposition)
     struct VehiclePositions: GTFSEndpoint {

--- a/Sources/WMATA/Endpoint.swift
+++ b/Sources/WMATA/Endpoint.swift
@@ -11,7 +11,7 @@ import GTFS
 
 /// Protocol defining a WMATA API endpoint.
 ///
-/// Used to make requests and receive responses from an API. Endpoints are available in ``Rail`` for MetroRail and ``Bus`` for MetroBus.
+/// Used to make requests and receive responses from an API. Endpoints are available in ``Rail`` for Metrorail and ``Bus`` for Metrobus.
 public protocol Endpoint: WMATADecoding, Hashable {
     /// The response WMATA sends back when calling this endpoint
     associatedtype Response

--- a/Sources/WMATA/Line.swift
+++ b/Sources/WMATA/Line.swift
@@ -8,10 +8,10 @@
 import Combine
 import Foundation
 
-/// A MetroRail line
+/// A Metrorail line
 ///
-/// Represents the various, colorful rail lines within the MetroRail system.
-/// ![MetroRail system map](metrorail-map)
+/// Represents the various, colorful rail lines within the Metrorail system.
+/// ![Metrorail system map](metrorail-map)
 public enum Line: String, CaseIterable, Codable, Hashable, Equatable, RawRepresentable {
     /// Red Line
     case red = "RD"

--- a/Sources/WMATA/Rail.swift
+++ b/Sources/WMATA/Rail.swift
@@ -8,18 +8,18 @@
 import Foundation
 import GTFS
 
-/// MetroRail endpoints
+/// Metrorail endpoints
 ///
-/// The various endpoints defined here allow you to call MetroRail APIs. For an overview see <doc:Endpoints>
+/// The various endpoints defined here allow you to call Metrorail APIs. For an overview see <doc:Endpoints>
 ///
 /// > Tip: You can use endpoints here like so: `Rail.Lines(...)`
 public enum Rail {
-    /// MetroRail GTFS endpoints
+    /// Metrorail GTFS endpoints
     public enum GTFS {}
 }
 
 public extension Rail {
-    /// All MetroRail ``Line``s
+    /// All Metrorail ``Line``s
     ///
     /// [WMATA Lines Documentation](https://developer.wmata.com/docs/services/5476364f031f590f38092507/operations/5476364f031f5909e4fe330c)
     struct Lines: JSONEndpoint {
@@ -370,7 +370,7 @@ public extension Rail {
                 self.standardRoutes = standardRoutes
             }
             
-            /// A MetroRail route
+            /// A Metrorail route
             public struct StandardRoute: Codable, Equatable, Hashable {
                 /// Line of this route
                 public let line: Line
@@ -477,7 +477,7 @@ public extension Rail {
                 self.trackCircuits = trackCircuits
             }
             
-            /// A MetroRail track circuit
+            /// A Metrorail track circuit
             public struct TrackCircuit: Codable, Equatable, Hashable {
                 /// The type of a track
                 ///
@@ -525,7 +525,7 @@ public extension Rail {
                     self.neighbors = neighbors
                 }
                 
-                /// A MetroRail track neighbor
+                /// A Metrorail track neighbor
                 ///
                 /// ![A neighboring track diagram](track-neighbors)
                 ///
@@ -822,7 +822,7 @@ public extension Rail {
         }
     }
     
-    /// Reported MetroRail incidents (significant disruptions and delays to normal service).
+    /// Reported Metrorail incidents (significant disruptions and delays to normal service).
     ///
     /// The data is identical to [WMATA's Metrorail Service Status feed](http://www.metroalerts.info/rss.aspx?rs).
     ///
@@ -865,7 +865,7 @@ public extension Rail {
                 self.incidents = incidents
             }
             
-            /// A MetroRail incident
+            /// A Metrorail incident
             public struct Incident: Codable, Equatable, Hashable {
                 /// Unique identifier for an incident.
                 public let incidentID: String
@@ -1120,7 +1120,7 @@ public extension Rail {
                 /// Can be `nil` when a train is first appearing in API. Calling the API again after the next refresh should give the train a location.
                 public let locationName: String?
                 
-                /// The time until arrival. Matches signs within a MetroRail station
+                /// The time until arrival. Matches signs within a Metrorail station
                 ///
                 /// Sometimes a number in ``minutes(_:)``, can also be ``arriving``, ``boarding``, ``delayed`` or ``unknown``.
                 public enum Minutes: Codable, Equatable, Hashable {
@@ -1844,9 +1844,9 @@ public extension Rail {
 
 public extension Rail.GTFS {
     
-    /// GTFS 1.0 Service Alerts feed for MetroRail
+    /// GTFS 1.0 Service Alerts feed for Metrorail
     ///
-    /// Service alerts represent higher level problems with station, lines or all of MetroRail
+    /// Service alerts represent higher level problems with station, lines or all of Metrorail
     ///
     /// [GTFS Alerts Documentation](https://gtfs.org/reference/realtime/v1/#message-alert)
     struct Alerts: GTFSEndpoint {
@@ -1862,7 +1862,7 @@ public extension Rail.GTFS {
         public weak var delegate: GTFSEndpointDelegate<Self>? = nil
     }
     
-    /// GTFS 1.0 Trip Updates feed for MetroRail
+    /// GTFS 1.0 Trip Updates feed for Metrorail
     ///
     /// Trip updates represent fluctuations in the timetable
     ///
@@ -1880,9 +1880,9 @@ public extension Rail.GTFS {
         public weak var delegate: GTFSEndpointDelegate<Self>? = nil
     }
     
-    /// GTFS 1.0 Vehicle Positions feed for MetroRail
+    /// GTFS 1.0 Vehicle Positions feed for Metrorail
     ///
-    /// Locations of MetroRail trains
+    /// Locations of Metrorail trains
     ///
     /// [GTFS Trip Updates Documentation](https://gtfs.org/reference/realtime/v1/#message-vehicleposition)
     struct VehiclePositions: GTFSEndpoint {

--- a/Sources/WMATA/Route.swift
+++ b/Sources/WMATA/Route.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
-/// A MetroBus route
+/// A Metrobus route
 ///
-/// MetroBus routes are the numbers visible at the top left of the front of any MetroBus. Values are route IDs rather than route names. You can fetch all MetroBus routes with ``Bus/Routes``.
+/// Metrobus routes are the numbers visible at the top left of the front of any Metrobus. Values are route IDs rather than route names. You can fetch all Metrobus routes with ``Bus/Routes``.
 ///
-/// ![A MetroBus displaying the route E4](metrobus-e4-route)
+/// ![A Metrobus displaying the route E4](metrobus-e4-route)
 public typealias Route = String

--- a/Sources/WMATA/Station.swift
+++ b/Sources/WMATA/Station.swift
@@ -7,13 +7,13 @@
 
 import Foundation
 
-/// A MetroRail station
+/// A Metrorail station
 ///
 /// A station with in enum represents a single level within a physical station. Stations in this enum are named after the first name given by WMATA, with no shortenings. So, Archives-Navy Memorial-Penn Quarter is represented as ``archives``.
 ///
 /// Physical stations with multiple levels like L'Enfant Plaza require multiple station codes. For example, `lenfantPlazaUpper` is a single level within the L'Enfant Plaza station, along with `lenfantPlazaLower`. All stations follow this `...Upper` and `...Lower` naming convention. You can also use ``together`` or ``allTogether`` to get all relevant stations.
 ///
-/// ![A train passes at the Pentagon City MetroRail station](metrorail-station)
+/// ![A train passes at the Pentagon City Metrorail station](metrorail-station)
 public enum Station: String, CaseIterable, Codable, Equatable, Hashable, RawRepresentable {
     /// Red line tracks for Metro Center
     case metroCenterUpper = "A01"

--- a/Sources/WMATA/Stop.swift
+++ b/Sources/WMATA/Stop.swift
@@ -8,11 +8,11 @@
 import Combine
 import Foundation
 
-/// A MetroBus stop
+/// A Metrobus stop
 ///
-/// Values are stop IDs rather than stop names. MetroBus stops are numerous and defining them all explicitly is not feasible. Check the ``Bus/StopsSearch`` endpoint from WMATA to get all avalable stops.
+/// Values are stop IDs rather than stop names. Metrobus stops are numerous and defining them all explicitly is not feasible. Check the ``Bus/StopsSearch`` endpoint from WMATA to get all avalable stops.
 ///
-/// Stop IDs are the same as you would see on signs at a MetroBus stop.
+/// Stop IDs are the same as you would see on signs at a Metrobus stop.
 ///
-/// ![A sign at a MetroBus stop displaying stop ID 1001037](metrobus-stop)
+/// ![A sign at a Metrobus stop displaying stop ID 1001037](metrobus-stop)
 public typealias Stop = String

--- a/Sources/WMATA/WMATA.docc/Documentation.md
+++ b/Sources/WMATA/WMATA.docc/Documentation.md
@@ -4,9 +4,9 @@ WMATA is an interface to the Washington Metropolitan Area Transit Authority API.
 
 ## Overview
 
-WMATA supports both the Standard and GTFS APIs for both MetroRail and MetroBus. WMATA uses a series of ``Endpoint``s to make requests to the WMATA API on your behalf. WMATA augments some responses from the API with structures like ``Station`` and ``Stop`` that allow you to get additional information without calling the API.
+WMATA supports both the Standard and GTFS APIs for both Metrorail and Metrobus. WMATA uses a series of ``Endpoint``s to make requests to the WMATA API on your behalf. WMATA augments some responses from the API with structures like ``Station`` and ``Stop`` that allow you to get additional information without calling the API.
 
-![A MetroRail station with a train passing](center-platforms)
+![A Metrorail station with a train passing](center-platforms)
 
 ## Quickstart
 
@@ -41,14 +41,14 @@ For more details, check out <doc:Endpoints>.
 - <doc:Responses>
 - <doc:StandardGTFSAPI>
 
-### MetroRail
+### Metrorail
 
 - ``Station``
 - ``Line``
 - ``Rail``
 - ``Rail/GTFS``
 
-### MetroBus
+### Metrobus
 
 - ``Stop``
 - ``Route``

--- a/Sources/WMATA/WMATA.docc/Endpoints.md
+++ b/Sources/WMATA/WMATA.docc/Endpoints.md
@@ -6,9 +6,9 @@ Understanding endpoints and how to make requests the way you need.
 
 WMATA provides two formats for data from their API: JSON and GTFS. In this package, I refer to the JSON API as the "Standard API" and thr GTFS API as simply as the "GTFS API".
 
-Endpoints in this package are split into four categories: ``Rail`` and  ``Bus`` for JSON APIs for MetroRail and MetroBus respectively, and ``Rail/GTFS`` and ``Bus/GTFS`` for GTFS APIs for MetroRail and MetroBus respectively.
+Endpoints in this package are split into four categories: ``Rail`` and  ``Bus`` for JSON APIs for Metrorail and Metrobus respectively, and ``Rail/GTFS`` and ``Bus/GTFS`` for GTFS APIs for Metrorail and Metrobus respectively.
 
-Each API provided by WMATA is defined as an ``Endpoint`` within this package. So, the [MetroBus Routes API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6a) is defined as ``Bus/Routes`` and the [MetroRail Trip Updates GTFS API](https://developer.wmata.com/docs/services/gtfs/operations/5cdc51ea7a6be320cab064fe) is defined as ``Rail/GTFS/TripUpdates``. I would recommend exploring each namespace for relevant APIs. Names match with names on [WMATA's Developer Website](https://developer.wmata.com).
+Each API provided by WMATA is defined as an ``Endpoint`` within this package. So, the [Metrobus Routes API](https://developer.wmata.com/docs/services/54763629281d83086473f231/operations/5476362a281d830c946a3d6a) is defined as ``Bus/Routes`` and the [Metrorail Trip Updates GTFS API](https://developer.wmata.com/docs/services/gtfs/operations/5cdc51ea7a6be320cab064fe) is defined as ``Rail/GTFS/TripUpdates``. I would recommend exploring each namespace for relevant APIs. Names match with names on [WMATA's Developer Website](https://developer.wmata.com).
 
 ## Usage
 

--- a/Sources/WMATA/WMATA.docc/Responses.md
+++ b/Sources/WMATA/WMATA.docc/Responses.md
@@ -18,13 +18,13 @@ Here's some examples of what you'll find in these responses. Let's look at ``Rai
 
 This package converts station codes and line codes into ``Station`` and ``Line`` respectively. So, in WMATA's response for the ``Rail/NextTrains`` API, you could receive `E10` as a destination station. However, ``Rail/NextTrains/Response/Prediction/destination`` maps `E10` to ``Station/greenbelt`` instead. You can still receive the original station code by calling `rawValue` on ``Station/greenbelt``. ``Station`` instances also provide many helper variables and functions to receive data this is not available via the API.
 
-Similarly for line codes, `BL` gets converted to ``Line/blue`` in many responses. MetroBus stops and routes are also marked as their own type, but they are simply backed by strings with no additional information available.
+Similarly for line codes, `BL` gets converted to ``Line/blue`` in many responses. Metrobus stops and routes are also marked as their own type, but they are simply backed by strings with no additional information available.
 
 ### Data Wrangling
 
 In some cases data that comes from WMATA's API can be deceiptful or confusing. This package makes attempts to place this data into nicer formats. Let's look at some examples.
 
-In the ``Rail/NextTrains`` API, the `Car` field, for checking the number of cars a train has, can be `"6"` or `"8"`, as you might expect from typical MetroRail usage. However, it can also be `"-"` or `nil`. Stange values that can be tricky to check for since all of this data is just a string. In this package ``Rail/NextTrains/Response/Prediction/car`` is parsed and is an optional enum that can only be `.six`, `.eight` or `nil`.
+In the ``Rail/NextTrains`` API, the `Car` field, for checking the number of cars a train has, can be `"6"` or `"8"`, as you might expect from typical Metrorail usage. However, it can also be `"-"` or `nil`. Stange values that can be tricky to check for since all of this data is just a string. In this package ``Rail/NextTrains/Response/Prediction/car`` is parsed and is an optional enum that can only be `.six`, `.eight` or `nil`.
 
 Again in the ``Rail/NextTrains`` API, the `Min` field, for checking the minutes until a train arrives, can be a number within a string, `"ARR"`, `"BRD"`, `"---"` or `""`. Again, this is confusing and difficult to parse. In this package ``Rail/NextTrains/Response/Prediction/minutes-swift.property`` is parsed into an enum with possible values `.minutes(Int)`, `.arriving`, `.boarding`, or `.unknown`. This should allow you to more easily parse the data coming from WMATA's API in your app in a swifty way.
 

--- a/Sources/WMATA/WMATA.docc/StandardGTFSAPI.md
+++ b/Sources/WMATA/WMATA.docc/StandardGTFSAPI.md
@@ -14,9 +14,9 @@ The Standard API is the best supported by this package, and is recommended for m
 
 ## GTFS
 
-The GTFS API is a set of 3 endpoints available for both MetroRail and MetroBus based on the [General Transit Feed Specification](https://gtfs.org). GTFS is a standard data format split into two parts: GTFS and GTFS-RT (Real Time). To receive GTFS data, which in the case of WMATA is simply a zip file, you will need to use the [GTFS Package](https://github.com/emma-k-alexandra/GTFS) directly. `GTFS` is a dependency of this package. This package only supports calling GTFS-RT endpoints published by WMATA.
+The GTFS API is a set of 3 endpoints available for both Metrorail and Metrobus based on the [General Transit Feed Specification](https://gtfs.org). GTFS is a standard data format split into two parts: GTFS and GTFS-RT (Real Time). To receive GTFS data, which in the case of WMATA is simply a zip file, you will need to use the [GTFS Package](https://github.com/emma-k-alexandra/GTFS) directly. `GTFS` is a dependency of this package. This package only supports calling GTFS-RT endpoints published by WMATA.
 
-GTFS-RT endpoints return data for the entire MetroBus or MetroRail system with a single call. This may save you from making multiple calls with the Standard API at the cost of larger and more complex responses. GTFS-RT endpoints return data via a [Protocol Buffer](https://developers.google.com/protocol-buffers) which can substantally reduce response size at the cost of complexity.
+GTFS-RT endpoints return data for the entire Metrobus or Metrorail system with a single call. This may save you from making multiple calls with the Standard API at the cost of larger and more complex responses. GTFS-RT endpoints return data via a [Protocol Buffer](https://developers.google.com/protocol-buffers) which can substantally reduce response size at the cost of complexity.
 
 Protocol Buffers are not easily convertable into Swift structures. For example, [responses from the GTFS API are not `Codable`](https://github.com/apple/swift-protobuf/issues/657) and future `Codable` support looks bleak. So, you will encounter more difficulty parsing the responses from this API.
 

--- a/Sources/WMATA/WMATA.docc/v12 Migration Guide.md
+++ b/Sources/WMATA/WMATA.docc/v12 Migration Guide.md
@@ -8,7 +8,7 @@ WMATA.swift v12 removes the need to use `StationSet` when making calls to ``Rail
 
 This part of the package now works more similarly to the rest of the package.
 
-If you wish to make a request for trains at all MetroRail stations, omit the `stations` parameter when using ``Rail/NextTrains/init(key:stations:delegate:)``. Example:
+If you wish to make a request for trains at all Metrorail stations, omit the `stations` parameter when using ``Rail/NextTrains/init(key:stations:delegate:)``. Example:
 
 ```swift
 let nextTrains = Rail.NextTrains(key: API_KEY)


### PR DESCRIPTION
WMATA uses _Metrobus_ and _Metrorail_ (_bus_ and _rail_ are not capitalized), so update the documentation to match WMATA capitalization.