### PR TITLE
feat: Add Line.sharesTracksWith

### DIFF
--- a/Sources/WMATA/Date.swift
+++ b/Sources/WMATA/Date.swift
@@ -22,8 +22,8 @@ extension Date: URLQueryItemConvertible {
 }
 
 extension DateFormatter {
-    static var wmataQueryFormat: Self {
-        let formatter = Self()
+    static var wmataQueryFormat: DateFormatter {
+        let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = TimeZone(abbreviation: "EST")!

--- a/Sources/WMATA/Decoder.swift
+++ b/Sources/WMATA/Decoder.swift
@@ -24,7 +24,7 @@ public extension JSONDecoder.KeyDecodingStrategy {
     /// Decodes keys in responses from the WMATA Standard API.
     ///
     /// This strategy decodes certain keys into completely separate keys defined in endpoint responses. This includes renaming and mapping certain values to `nil`. In all cases, this stategy will decode pascal case keys into camel case keys appropriate for Swift APIs.
-    static var convertFromWMATA: Self {
+    static var convertFromWMATA: JSONDecoder.KeyDecodingStrategy {
         .custom { codingPath in
             let relevantKey = codingPath.last!
             
@@ -43,7 +43,7 @@ public extension JSONDecoder.KeyDecodingStrategy {
 }
 
 extension JSONDecoder.KeyDecodingStrategy {
-    static var convertFromPascalCase: Self {
+    static var convertFromPascalCase: JSONDecoder.KeyDecodingStrategy {
         .custom { codingPath in
             PascalCaseKey(stringValue: codingPath.last!.stringValue)
         }
@@ -148,8 +148,8 @@ public extension DateFormatter {
     /// Dates from WMATA's API are _nearly_ ISO-8601, but not quite. They're missing a timezone incidator, which is non-standard. This formatter assumes EST, which is what WMATA states all of their dates are formatted in.
     ///
     /// > Note: If you're having issues with dates coming from the API, check to confirm the timezone is correct. This formatter assumes EST, but I've been burned by the API enough times to not trust WMATA's claim that these dates are always EST.
-    static var wmataFormat: Self {
-        let formatter = Self()
+    static var wmataFormat: DateFormatter {
+        let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = TimeZone(abbreviation: "EST")!

--- a/Sources/WMATA/EndpointDelegate.swift
+++ b/Sources/WMATA/EndpointDelegate.swift
@@ -15,7 +15,7 @@ open class EndpointDelegate<Parent: Endpoint>: NSObject, URLSessionDownloadDeleg
     
     /// Handle a response from a background request. Override this in your own delegate.
     open func received(_ response: Result<Parent.Response, WMATAError>) {
-        assertionFailure("Base EndpointDelegate received response. Override `func received(_ response: Result<Parent.Response, WMATAError>)`")
+        assertionFailure("Base EndpointDelegate received response. Override `func received(_ response: Result<Parent.Response, WMATAError>)` to receive background requests.")
     }
     
     /// An indentifier used when running in an app extension.
@@ -79,8 +79,14 @@ extension EndpointDelegate {
 
 /// A delegate for Standard API endpoints.
 ///
-/// To make your own delegate, sublcass this and override ``EndpointDelegate/received(_:)``.
+/// To make your own delegate, sublcass this and override ``received(_:)``.
 open class JSONEndpointDelegate<Parent: JSONEndpoint>: EndpointDelegate<Parent> {
+    
+    /// Handle a response from a background request. Override this in your own delegate.
+    open override func received(_ response: Result<Parent.Response, WMATAError>) {
+        assertionFailure("JSONEndpointDelegate received response. Override `func received(_ response: Result<Parent.Response, WMATAError>)` to receive background requests.")
+    }
+    
     /// Turns responses from the Standard API into ``Endpoint/Response`` structures or ``WMATAError``.
     open override func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         received(loadData(from: location)
@@ -92,8 +98,14 @@ open class JSONEndpointDelegate<Parent: JSONEndpoint>: EndpointDelegate<Parent> 
 
 /// A delegate for GTFS API endpoints.
 ///
-/// To make your own delegate, sublcass this and override ``EndpointDelegate/received(_:)``.
+/// To make your own delegate, sublcass this and override ``received(_:)``.
 open class GTFSEndpointDelegate<Parent: GTFSEndpoint>: EndpointDelegate<Parent> {
+    
+    /// Handle a response from a background request. Override this in your own delegate.
+    open override func received(_ response: Result<Parent.Response, WMATAError>) {
+        assertionFailure("GTFSEndpointDelegate received response. Override `func received(_ response: Result<Parent.Response, WMATAError>)` to receive background requests.")
+    }
+    
     /// Turns responses from the GTFS API into `TransitRealtime_FeedMessage` or ``WMATAError``.
     open override func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         received(loadData(from: location)

--- a/Sources/WMATA/Line.swift
+++ b/Sources/WMATA/Line.swift
@@ -9,24 +9,26 @@ import Combine
 import Foundation
 
 /// A Metrorail line
+/// ![Metrorail system map](metrorail-map)
 ///
 /// Represents the various, colorful rail lines within the Metrorail system.
-/// ![Metrorail system map](metrorail-map)
+///
+/// `Lines.allCases` returns lines ordered as they are in on the system map.
 public enum Line: String, CaseIterable, Codable, Hashable, Equatable, RawRepresentable {
     /// Red Line
     case red = "RD"
     
-    /// Blue Line
-    case blue = "BL"
-    
-    /// Yellow Line
-    case yellow = "YL"
-    
     /// Orange Line
     case orange = "OR"
     
+    /// Blue Line
+    case blue = "BL"
+    
     /// Green Line
     case green = "GR"
+    
+    /// Yellow Line
+    case yellow = "YL"
     
     /// Silver Line
     case silver = "SV"
@@ -59,8 +61,28 @@ public extension Line {
     
     /// Deprecated. Use `allCases` instead.
     @available(*, deprecated, renamed: "allCases", message: "All lines are now current.")
-    static var allCurrent: [Self] {
-        [.red, .blue, .yellow, .orange, .green, .silver]
+    static var allCurrent: [Line] {
+        [.red, .orange, .blue, .green, .yellow, .silver]
+    }
+    
+    /// Lines that this line shares tracks with at any point.
+    ///
+    /// Lines are in system map order.
+    var sharesTracksWith: [Line] {
+        switch self {
+        case .red:
+            return []
+        case .blue:
+            return [.orange, .yellow, .silver]
+        case .yellow:
+            return [.blue, .green]
+        case .orange:
+            return [.silver, .blue]
+        case .green:
+            return [.yellow]
+        case .silver:
+            return [.orange, .blue]
+        }
     }
 }
 

--- a/Sources/WMATA/Route.swift
+++ b/Sources/WMATA/Route.swift
@@ -8,8 +8,13 @@
 import Foundation
 
 /// A Metrobus route
+/// ![A Metrobus displaying the route E4](metrobus-e4-route)
 ///
 /// Metrobus routes are the numbers visible at the top left of the front of any Metrobus. Values are route IDs rather than route names. You can fetch all Metrobus routes with ``Bus/Routes``.
 ///
-/// ![A Metrobus displaying the route E4](metrobus-e4-route)
+/// Example IDs: `10A` or `10Av1` or `79*1`.
+///
+/// Some routes have _variations_ that are slight modifications to a route. The last two examples above are for route variations. Some endpoints can accept routes with variations and others cannot. Individual endpoints indicate what kinds of routes they can accept in their documentation.
 public typealias Route = String
+
+// TODO: Implement base route or route without variation function for either internal or user use.

--- a/Sources/WMATA/Station.swift
+++ b/Sources/WMATA/Station.swift
@@ -8,12 +8,11 @@
 import Foundation
 
 /// A Metrorail station
+/// ![A train passes at the Pentagon City Metrorail station](metrorail-station)
 ///
 /// A station with in enum represents a single level within a physical station. Stations in this enum are named after the first name given by WMATA, with no shortenings. So, Archives-Navy Memorial-Penn Quarter is represented as ``archives``.
 ///
-/// Physical stations with multiple levels like L'Enfant Plaza require multiple station codes. For example, `lenfantPlazaUpper` is a single level within the L'Enfant Plaza station, along with `lenfantPlazaLower`. All stations follow this `...Upper` and `...Lower` naming convention. You can also use ``together`` or ``allTogether`` to get all relevant stations.
-///
-/// ![A train passes at the Pentagon City Metrorail station](metrorail-station)
+/// Physical stations with multiple levels like L'Enfant Plaza require multiple station codes. For example, `lenfantPlazaUpper` is a single level within the L'Enfant Plaza station, along with `lenfantPlazaLower`. All stations follow this `...Upper` and `...Lower` naming convention. You can also use ``together`` or ``allTogether`` or `Array.lenfantPlaza`, etc. to get all relevant stations.
 public enum Station: String, CaseIterable, Codable, Equatable, Hashable, RawRepresentable {
     /// Red line tracks for Metro Center
     case metroCenterUpper = "A01"
@@ -441,14 +440,14 @@ public extension Station {
         }
     }
 
-    /// The ``Line``s this station is on
+    /// The ``Line``s this station is on in system map order.
     var lines: [Line] {
         switch self {
         case .metroCenterUpper, .galleryPlaceUpper, .fortTottenUpper, .farragutNorth, .dupontCircle, .woodleyPark, .clevelandPark, .vanNess, .tenleytown, .friendshipHeights, .bethesda, .medicalCenter, .grosvenor, .northBethesda, .twinbrook, .rockville, .shadyGrove, .judiciarySquare, .unionStation, .rhodeIslandAve, .brookland, .takoma, .silverSpring, .forestGlen, .wheaton, .glenmont, .noma:
             return [.red]
 
         case .metroCenterLower, .lenfantPlazaLower, .mcphersonSquare, .farragutWest, .foggyBottom, .rosslyn, .federalTriangle, .smithsonian, .federalCenterSW, .capitolSouth, .easternMarket, .potomacAve, .stadium:
-            return [.blue, .orange, .silver]
+            return [.orange, .blue, .silver]
 
         case .arlingtonCemetery, .vanDornStreet, .franconia:
             return [.blue]
@@ -489,7 +488,7 @@ public extension Station {
     /// All stations that are currently open to the public.
     ///
     /// Potomac Yard and Silver Line Phase 2 expansion stations are excluded.
-    static var allOpen: [Self] {
+    static var allOpen: [Station] {
         [.metroCenterUpper, .farragutNorth, .dupontCircle, .woodleyPark, .clevelandPark, .vanNess, .tenleytown, .friendshipHeights, .bethesda, .medicalCenter, .grosvenor, .northBethesda, .twinbrook, .rockville, .shadyGrove, .galleryPlaceUpper, .judiciarySquare, .unionStation, .rhodeIslandAve, .brookland, .fortTottenUpper, .takoma, .silverSpring, .forestGlen, .wheaton, .glenmont, .noma, .metroCenterLower, .mcphersonSquare, .farragutWest, .foggyBottom, .rosslyn, .arlingtonCemetery, .pentagon, .pentagonCity, .crystalCity, .ronaldReaganWashingtonNationalAirport, .braddockRoad, .kingSt, .eisenhowerAvenue, .huntington, .federalTriangle, .smithsonian, .lenfantPlazaLower, .federalCenterSW, .capitolSouth, .easternMarket, .potomacAve, .stadium, .minnesotaAve, .deanwood, .cheverly, .landover, .newCarrollton, .mtVernonSq7thSt, .shaw, .uStreet, .columbiaHeights, .georgiaAve, .fortTottenLower, .westHyattsville, .princeGeorgesPlaza, .collegePark, .greenbelt, .galleryPlaceLower, .archives, .lenfantPlazaUpper, .waterfront, .navyYard, .anacostia, .congressHeights, .southernAvenue, .naylorRoad, .suitland, .branchAve, .benningRoad, .capitolHeights, .addisonRoad, .morganBoulevard, .largoTownCenter, .vanDornStreet, .franconia, .courtHouse, .clarendon, .virginiaSquare, .ballston, .eastFallsChurch, .westFallsChurch, .dunnLoring, .vienna, .mcLean, .tysonsCorner, .greensboro, .springHill, .wiehle]
     }
 
@@ -536,7 +535,7 @@ public extension Station {
     /// See ``Station`` for more details.
     ///
     /// - Returns: The ``Station`` within the same physical station, if there is one. Otherwise, `nil`.
-    var together: Self? {
+    var together: Station? {
         switch self {
         case .fortTottenUpper:
             return .fortTottenLower
@@ -571,30 +570,39 @@ public extension Station {
     /// See ``Station`` for more details.
     ///
     /// - Returns: This station and the ``together``, if there is one. Otherwise, just this station.
-    var allTogether: [Self] {
-        if let together = self.together {
+    var allTogether: [Station] {
+        if let together = together {
             return [self, together]
         }
 
         return [self]
     }
+    
+    /// If this station or any station ``together`` connects to the given line.
+    ///
+    /// - Parameter line: The line to check for a connection
+    ///
+    /// - Returns: If the given line has a connection at this station
+    func connects(to line: Line) -> Bool {
+        allTogether.flatMap(\.lines).contains(line)
+    }
 
     /// Get the connecting lines at this station for the given line.
     ///
-    /// - Parameter to: The line to get connections for; if nil, returns all lines at this station.
+    /// - Parameter line: The line to get connections for; if nil, returns all lines at this station.
     ///
-    /// - Returns: An array of connecting lines; this is empty if the `to` line is the only line at this station.
+    /// - Returns: An array of connecting lines; this is empty if `line` is the only line at this station.
     func connections(to line: Line?) -> [Line] {
-        self.lines.filter({ $0 != line })
+        lines.filter { $0 != line }
     }
 
-    /// Get the connecting lines at this station and any station together with it for the given line.
+    /// Get the connecting lines at this station and any station ``together`` with it for the given line.
     ///
-    /// - Parameter to: The line to get connections for; if nil, returns all lines at this station.
+    /// - Parameter line: The line to get connections for; if nil, returns all lines at this station.
     ///
-    /// - Returns: An array of connecting lines; this is empty if the `to` line is the only line at this station.
+    /// - Returns: An array of connecting lines; this is empty if `line` is the only line at this station.
     func allConnections(to line: Line?) -> [Line] {
-        self.allTogether.flatMap({ $0.connections(to: line) })
+        allTogether.flatMap { $0.connections(to: line) }
     }
 }
 

--- a/Sources/WMATA/Stop.swift
+++ b/Sources/WMATA/Stop.swift
@@ -9,10 +9,11 @@ import Combine
 import Foundation
 
 /// A Metrobus stop
+/// ![A sign at a Metrobus stop displaying stop ID 1001037](metrobus-stop)
 ///
 /// Values are stop IDs rather than stop names. Metrobus stops are numerous and defining them all explicitly is not feasible. Check the ``Bus/StopsSearch`` endpoint from WMATA to get all avalable stops.
 ///
 /// Stop IDs are the same as you would see on signs at a Metrobus stop.
 ///
-/// ![A sign at a Metrobus stop displaying stop ID 1001037](metrobus-stop)
+/// Example ID: `1001037`
 public typealias Stop = String

--- a/Sources/WMATA/WMATA.docc/BackgroundRequests.md
+++ b/Sources/WMATA/WMATA.docc/BackgroundRequests.md
@@ -75,11 +75,3 @@ class CustomEndpointDelegate: JSONEndpointDelegate<Bus.NextBuses> {
 ```
 
 You can read more about shared container identifiers in the "Performing Uploads and Downloads" section of Apple's [App Extension Programming Guide](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html#//apple_ref/doc/uid/TP40014214-CH21-SW1).
-
-## Topics
-
-### Delegates
-
-- ``JSONEndpointDelegate``
-- ``GTFSEndpointDelegate``
-- ``EndpointDelegate``

--- a/Sources/WMATA/WMATA.docc/Documentation.md
+++ b/Sources/WMATA/WMATA.docc/Documentation.md
@@ -41,19 +41,10 @@ For more details, check out <doc:Endpoints>.
 - <doc:Responses>
 - <doc:StandardGTFSAPI>
 
-### Metrorail
+### Systems
 
-- ``Station``
-- ``Line``
-- ``Rail``
-- ``Rail/GTFS``
-
-### Metrobus
-
-- ``Stop``
-- ``Route``
-- ``Bus``
-- ``Bus/GTFS``
+- <doc:Metrorail>
+- <doc:Metrobus>
 
 ### Supporting structures
 
@@ -65,6 +56,7 @@ For more details, check out <doc:Endpoints>.
 - <doc:BackgroundRequests>
 - ``JSONEndpointDelegate``
 - ``GTFSEndpointDelegate``
+- ``EndpointDelegate``
 
 ### Advanced
 

--- a/Sources/WMATA/WMATA.docc/Metrobus.md
+++ b/Sources/WMATA/WMATA.docc/Metrobus.md
@@ -1,0 +1,35 @@
+# Metrobus
+
+Structures and Endpoints for calling Metrobus APIs.
+
+## Overview
+
+Metrobus APIs are used to retrieve information about bus stops and routes. 
+
+In this package ``Stop`` represents a bus stop and a simply a `String` of a stop's ID like `1001037`.
+
+``Route`` represents a bus route and is also a `String` of a route's ID like `10Av1`.
+ 
+## Topics
+
+### Structures
+
+- ``Stop``
+- ``Route``
+
+### Standard Endpoints
+
+- ``Bus/Positions``
+- ``Bus/Incidents``
+- ``Bus/PathDetails``
+- ``Bus/RouteSchedule``
+- ``Bus/NextBuses``
+- ``Bus/StopSchedule``
+- ``Bus/StopsSearch``
+- ``Bus/Routes``
+
+### GTFS Endpoints
+
+- ``Bus/GTFS/Alerts``
+- ``Bus/GTFS/TripUpdates``
+- ``Bus/GTFS/VehiclePositions``

--- a/Sources/WMATA/WMATA.docc/Metrorail.md
+++ b/Sources/WMATA/WMATA.docc/Metrorail.md
@@ -1,0 +1,41 @@
+# Metrorail
+
+Structures and Endpoints for calling Metrorail APIs.
+
+## Overview
+
+Metrorail APIs are used to retrieve information about train stations, routes and tracks. 
+
+In this package ``Station`` represents a train station and is an enumeration of all current and future Metrorail stations. You can use `Station` instances to retrieve additional information about a station without making a network request to the API.
+
+``Line`` represents the colorful train lines of the Metrorail system and is also an enumeration of all current lines. You can use `Line` instances to retrieve additional information about a line without making a network request.
+
+## Topics
+
+### Structures
+
+- ``Station``
+- ``Line``
+
+### Standard Endpoints
+
+- ``Rail/Lines``
+- ``Rail/StationEntrances``
+- ``Rail/TrainPositions``
+- ``Rail/StandardRoutes``
+- ``Rail/TrackCircuits``
+- ``Rail/StationToStation``
+- ``Rail/ElevatorAndEscalatorIncidents``
+- ``Rail/Incidents``
+- ``Rail/NextTrains``
+- ``Rail/StationInformation``
+- ``Rail/ParkingInformation``
+- ``Rail/PathBetweenStations``
+- ``Rail/StationTimings``
+- ``Rail/Stations``
+
+### GTFS Endpoints
+
+- ``Rail/GTFS/Alerts``
+- ``Rail/GTFS/TripUpdates``
+- ``Rail/GTFS/VehiclePositions``

--- a/Sources/WMATA/WMATAError.swift
+++ b/Sources/WMATA/WMATAError.swift
@@ -98,7 +98,7 @@ public enum WMATAError: Error {
                 self.message = message
             } else {
                 throw DecodingError.typeMismatch(
-                    Self.self,
+                    Message.self,
                     .init(
                         codingPath: container.codingPath,
                         debugDescription: "Key `message` or `Message` was not found in WMATAError.Message while decoding",

--- a/Tests/WMATATests/TestLine.swift
+++ b/Tests/WMATATests/TestLine.swift
@@ -17,4 +17,35 @@ class LineTests: XCTestCase {
         XCTAssertEqual(Line.green.name, "Green")
         XCTAssertEqual(Line.silver.name, "Silver")
     }
+    
+    func testSharesTracksWith() {
+        XCTAssertEqual(Line.red.sharesTracksWith, [])
+        XCTAssertEqual(
+            Line.blue.sharesTracksWith,
+            [.yellow, .orange, .silver]
+        )
+        XCTAssertEqual(
+            Line.yellow.sharesTracksWith,
+            [.blue, .green]
+        )
+        XCTAssertEqual(
+            Line.orange.sharesTracksWith,
+            [.silver, .blue]
+        )
+        XCTAssertEqual(
+            Line.green.sharesTracksWith,
+            [.yellow]
+        )
+        XCTAssertEqual(
+            Line.silver.sharesTracksWith,
+            [.orange, .blue]
+        )
+    }
+    
+    func testLineOrder() {
+        XCTAssertEqual(
+            Line.allCases,
+            [.red, .orange, .blue, .green, .yellow, .silver]
+        )
+    }
 }


### PR DESCRIPTION
feat: Add Station.connects(to:)
docs: Use name of structures instead of Self in user-facing places to improve documentation inside of Xcode
refactor: Place Line cases in system map order
refactor: Place arrays of Lines returned from hard coded functions into system map order
refactor(style): Station.connections(to:)
refactor(style): Station.allConnections(to:)
docs: rename `to` parameter of Station.connections(to:) and Station.allConnections(to:) to `line`
docs: Add DocC articles for Metrorail and Metrobus to better structure docs
docs: Remove Topics section from Background Requests article
refactor: Add received(_:) override to JSONEndpointDelegate and GTFSEndpointDelegate to improve docs
tests: add tests for Line order and Line.sharesTracksWith