### PR TITLE
fix: Response struct initializer property types now match the actual property types of the structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WMATA.swift
 
-WMATA.swift is a Swift interface to the [Washington Metropolitan Area Transit Authority API][wmata].
+WMATA.swift is a Swift interface to the [Washington Metropolitan Area Transit Authority API](https://developer.wmata.com).
 
 ## Contents
 
@@ -35,10 +35,12 @@ dependencies: [
 
 Full documentation is available within Xcode, or [on the web in a slightly broken form](https://github.com/emma-k-alexandra/WMATA.swift/blob/main/Sources/WMATA/WMATA.docc/Documentation.md). Thanks DocC!
 
+To view documentation within Xcode, within the menu navigate to `Product > Build Documentation`. WMATA's documentation will appear under `Workspace Documentation` within the Developer Documentation window. Navigate to `Window > Developer Documentation` to open this window.
+
 ## Dependencies
 
-- [GTFS][gtfs]
-- [swift-protobuf][swift-protobuf], for GTFS-RT feeds.
+- [GTFS](https://github.com/emma-k-alexandra/GTFS), for GTFS-RT feeds.
+- [swift-protobuf](https://github.com/apple/swift-protobuf), for GTFS-RT feeds.
 - [DVR](https://github.com/venmo/DVR), for testing.
 
 ## Contact
@@ -57,7 +59,3 @@ Todo:
 ## License
 
 WMATA.swift is released under the MIT license. [See LICENSE](https://github.com/emma-k-alexandra/WMATA.swift/blob/master/LICENSE) for details.
-
-[gtfs]: https://github.com/emma-k-alexandra/GTFS
-[swift-protobuf]: https://github.com/apple/swift-protobuf
-[wmata]: https://developer.wmata.com

--- a/Sources/WMATA/Bus.swift
+++ b/Sources/WMATA/Bus.swift
@@ -395,8 +395,9 @@ public extension Bus {
             /// Stop information
             public struct Stop: Codable, Equatable, Hashable {
                 /// The ``WMATA/Stop``
-                /// > Warning: A `stop` of `0` incidates an unknown stop.
-                public let stop: WMATA.Stop?
+                ///
+                /// The API value `"0"` is mapped to `nil`.
+                @MapToNil<WMATA.Stop, SingleZero> public var stop: WMATA.Stop?
                 
                 /// Stop name. May be slightly different from what is spoken or displayed in the bus.
                 public let name: String
@@ -419,7 +420,7 @@ public extension Bus {
                 ///     - longitude: longitude of stop
                 ///     - routes: Routes that provide service to this stop
                 public init(
-                    stop: WMATA.Stop,
+                    stop: WMATA.Stop?,
                     name: String,
                     latitude: Double,
                     longitude: Double,
@@ -505,8 +506,8 @@ public extension Bus {
             ///     - directionOne: List of route info
             public init(
                 name: String,
-                directionZero: [RouteInfo],
-                directionOne: [RouteInfo]
+                directionZero: [RouteInfo]?,
+                directionOne: [RouteInfo]?
             ) {
                 self.name = name
                 self.directionZero = directionZero
@@ -573,9 +574,10 @@ public extension Bus {
                 
                 /// Information about a ``Stop``
                 public struct StopInfo: Codable, Equatable, Hashable {
-                    /// A Metrobus stop
-                    /// > Warning: A `stop` of `0` incidates an unknown stop.
-                    public let stop: Stop?
+                    /// The ``WMATA/Stop``
+                    ///
+                    /// The API value `"0"` is mapped to `nil`.
+                    @MapToNil<Stop, SingleZero> public var stop: Stop?
                     
                     /// Stop name. May be slightly different from what is spoken or displayed in the bus.
                     public let stopName: String
@@ -594,7 +596,7 @@ public extension Bus {
                     ///     - stopSequence: Order of the stop in sequence
                     ///     - time: Scheduled departure time from this stop
                     public init(
-                        stop: Stop,
+                        stop: Stop?,
                         stopName: String,
                         stopSequence: Int,
                         time: Date
@@ -999,7 +1001,7 @@ public extension Bus {
                 /// Denotes the route variant’s grouping
                 ///
                 /// Lines are a combination of routes which lie in the same corridor and which have significant portions of their paths along the same roadways.
-                public let lineDescription: String
+                public let lineDescription: String?
 
                 /// Create a route response
                 ///
@@ -1010,7 +1012,7 @@ public extension Bus {
                 public init(
                     route: WMATA.Route,
                     name: String,
-                    lineDescription: String
+                    lineDescription: String?
                 ) {
                     self.route = route
                     self.name = name

--- a/Sources/WMATA/Decoder.swift
+++ b/Sources/WMATA/Decoder.swift
@@ -199,7 +199,7 @@ where
             return
         }
         
-        let stringValue = try container.decode(String.self)
+        let stringValue = try container.decode(MappedValues.ValueType.self)
         
         if MappedValues.allValues.contains(stringValue) {
             wrappedValue = nil
@@ -222,9 +222,10 @@ where
 ///
 /// These values must be defined at a static level like this to allow for initialization via `Decodable`.
 public protocol WMATAMappedValues: Hashable {
+    associatedtype ValueType: Codable & Hashable
     
     /// Values to map to `nil`.
-    static var allValues: [String] { get }
+    static var allValues: [ValueType] { get }
 }
 
 /// Map an empty string to `nil`.
@@ -245,4 +246,9 @@ public struct SingleDash: WMATAMappedValues, Equatable, Hashable {
 /// Map the value `"0"` to `nil`.
 public struct SingleZero: WMATAMappedValues, Equatable, Hashable {
     public static let allValues = ["0"]
+}
+
+/// Map the value `0` to `nil`.
+public struct SingleIntZero: WMATAMappedValues, Equatable, Hashable {
+    public static let allValues = [0]
 }

--- a/Sources/WMATA/EndpointDelegate.swift
+++ b/Sources/WMATA/EndpointDelegate.swift
@@ -13,6 +13,14 @@ import GTFS
 /// This class is not indented for direct use. Instead, subclass ``JSONEndpointDelegate`` or ``GTFSEndpointDelegate``.
 open class EndpointDelegate<Parent: Endpoint>: NSObject, URLSessionDownloadDelegate, WMATADecoding {
     
+    /// Create this endpoint delegate with a shared container identifier.
+    ///
+    /// See ``sharedContainerIdentifier``.
+    convenience init(sharedContainerIdentifier: String) {
+        self.init()
+        self.sharedContainerIdentifier = sharedContainerIdentifier
+    }
+    
     /// Handle a response from a background request. Override this in your own delegate.
     open func received(_ response: Result<Parent.Response, WMATAError>) {
         assertionFailure("Base EndpointDelegate received response. Override `func received(_ response: Result<Parent.Response, WMATAError>)` to receive background requests.")

--- a/Sources/WMATA/Rail.swift
+++ b/Sources/WMATA/Rail.swift
@@ -251,7 +251,7 @@ public extension Rail {
                 self.trainPositions = trainPositions
             }
             
-            /// A train position
+            /// The live location of a train within the rail system.
             public struct Positions: Codable, Equatable, Hashable {
                 /// Uniquely identifiable internal train identifier
                 public let trainID: String
@@ -261,8 +261,10 @@ public extension Rail {
                 /// Used by WMATA's Rail Scheduling and Operations Teams, as well as over open radio communication.
                 public let trainNumber: String
                 
-                /// Number of cars. Can be `0`.
-                public let carCount: Int
+                /// Number of cars.
+                ///
+                /// The API value `0` is mapped to `nil`.
+                @MapToNil<Int, SingleIntZero> public var carCount: Int?
                 
                 /// The direction of movement regardless of which track the train is on.
                 public let directionNumber: Int
@@ -322,7 +324,7 @@ public extension Rail {
                 public init(
                     trainID: String,
                     trainNumber: String,
-                    carCount: Int,
+                    carCount: Int?,
                     directionNumber: Int,
                     circuitID: Int,
                     destination: Station?,
@@ -1039,6 +1041,16 @@ public extension Rail {
             []
         }
         
+        /// Create a Next Trains call for all stations
+        ///
+        /// - Parameters
+        ///     - key: WMATA API Key for this request
+        ///     - delegate: Delegate to send background requests to
+        public init(key: APIKey, delegate: JSONEndpointDelegate<Rail.NextTrains>? = nil) {
+            self.key = key
+            self.delegate = delegate
+        }
+        
         /// Create a Next Trains call for multiple or all stations
         ///
         /// - Parameters
@@ -1081,7 +1093,7 @@ public extension Rail {
                 self.trains = trains
             }
             
-            ///
+            /// Information about upcoming train arrivals
             public struct Prediction: Codable, Equatable, Hashable {
                 /// The number of cars a train has
                 public enum Cars: String, Codable {
@@ -1222,9 +1234,9 @@ public extension Rail {
                     destination: Station?,
                     destinationName: String,
                     group: String,
-                    line: Line,
+                    line: Line?,
                     location: Station,
-                    locationName: String,
+                    locationName: String?,
                     minutes: Minutes
                 ) {
                     self.car = car

--- a/Sources/WMATA/WMATA.docc/AdvancedDecoding.md
+++ b/Sources/WMATA/WMATA.docc/AdvancedDecoding.md
@@ -91,3 +91,4 @@ You can create custom values to map to nil in your response structure by adoptin
 - ``EmptyString``
 - ``SingleDash``
 - ``SingleZero``
+- ``SingleIntZero``

--- a/Sources/WMATA/WMATA.docc/BackgroundRequests.md
+++ b/Sources/WMATA/WMATA.docc/BackgroundRequests.md
@@ -59,7 +59,15 @@ When your application receives a response from the API, `received(_:)` will be c
 
 ## Application Extensions
 
-In order to make background requests within an application extension, you must supply a [shared container identifier](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1409450-sharedcontaineridentifier) to your delegate. This is done with ``EndpointDelegate/sharedContainerIdentifier``. Modifying the example above's custom delegate to include a shared container identifier looks like:
+In order to make background requests within an application extension, you must supply a [shared container identifier](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1409450-sharedcontaineridentifier) to your delegate. This is done with ``EndpointDelegate/sharedContainerIdentifier``. Use the convenience initializer:
+
+```swift
+CustomEndpointDelegate(
+    sharedContainerIdentifier:  "com.mycompany.myapp.backgroundsession"
+)
+```
+
+or set the identifier in your own code:
 
 ```swift
 class CustomEndpointDelegate: JSONEndpointDelegate<Bus.NextBuses> {
@@ -74,4 +82,4 @@ class CustomEndpointDelegate: JSONEndpointDelegate<Bus.NextBuses> {
 }
 ```
 
-You can read more about shared container identifiers in the "Performing Uploads and Downloads" section of Apple's [App Extension Programming Guide](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html#//apple_ref/doc/uid/TP40014214-CH21-SW1).
+Also see Apple's [Downloading Files in the Background](https://developer.apple.com/documentation/foundation/url_loading_system/downloading_files_in_the_background).

--- a/Tests/WMATATests/TestLine.swift
+++ b/Tests/WMATATests/TestLine.swift
@@ -22,7 +22,7 @@ class LineTests: XCTestCase {
         XCTAssertEqual(Line.red.sharesTracksWith, [])
         XCTAssertEqual(
             Line.blue.sharesTracksWith,
-            [.yellow, .orange, .silver]
+            [.orange, .yellow, .silver]
         )
         XCTAssertEqual(
             Line.yellow.sharesTracksWith,


### PR DESCRIPTION
feat: add explicit Rail.NextTrains initializer without a station parameter
  It was previously possible to initialize Rail.NextTrains like this, but it didn't appear in autocomplete within Xcode.
feat: map the carCount value 0 to nil in Rail.PathDetails.Response.Positions
feat: Map the value "0" to nil for Stops in several Metrobus endpoint responses
feat: Added convenience initializer to EndpointDelegate for sharedContainerIdentifier
feat: Allow WMATAMappedValues to be any Codable & Hashable value, not just Strings
docs: Pointed to newer, more relevant Apple documentation for background requests
docs: Add information on how to build documentation in Xcode
test: correct line order of sharedTracksWith tests